### PR TITLE
fix(stop-check): skip enforcement for read-only sessions (#14)

### DIFF
--- a/hooks/stop-check.sh
+++ b/hooks/stop-check.sh
@@ -96,6 +96,47 @@ if [[ "$current_branch" == "main" || "$current_branch" == "master" ]]; then
   on_main=true
 fi
 
+# ── HOOK-14: Skip enforcement for read-only/conversational sessions ───────────
+# If the working tree is clean AND the branch has no commits ahead of its
+# upstream (or origin/main, or main), this session produced no code changes
+# that need gating. State may be non-empty from a prior dev session that
+# already wrapped up, or from carry-over across turns on the same branch —
+# but a pure Q&A turn shouldn't be blocked by heavyweight completion skills.
+# Dirty tree or unpushed local commits → keep enforcing.
+# Fixes alo-exp/silver-bullet#14.
+if git -C "$PWD" rev-parse --git-dir >/dev/null 2>&1; then
+  # "Clean" here means no tracked modifications, no staged changes, and no
+  # untracked files in the working tree — equivalent to `git status --porcelain`
+  # being empty. Untracked new files typically indicate WIP code for this
+  # session and should still trigger enforcement.
+  _tree_clean=false
+  if [[ -z "$(git -C "$PWD" status --porcelain 2>/dev/null)" ]]; then
+    _tree_clean=true
+  fi
+
+  if [[ "$_tree_clean" == true ]]; then
+    _cmp_ref=""
+    if _upstream=$(git -C "$PWD" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null); then
+      _cmp_ref="$_upstream"
+    elif git -C "$PWD" rev-parse --verify origin/main >/dev/null 2>&1; then
+      _cmp_ref="origin/main"
+    elif git -C "$PWD" rev-parse --verify origin/master >/dev/null 2>&1; then
+      _cmp_ref="origin/master"
+    elif [[ "$on_main" != true ]] && git -C "$PWD" rev-parse --verify main >/dev/null 2>&1; then
+      _cmp_ref="main"
+    fi
+
+    _ahead="0"
+    if [[ -n "$_cmp_ref" ]]; then
+      _ahead=$(git -C "$PWD" rev-list --count "${_cmp_ref}..HEAD" 2>/dev/null || printf '0')
+    fi
+    if [[ "$_ahead" == "0" ]]; then
+      # Clean tree and no local-only commits → nothing to deploy → skip.
+      exit 0
+    fi
+  fi
+fi
+
 # ── Read state file ───────────────────────────────────────────────────────────
 state_contents=""
 [[ -f "$state_file" ]] && state_contents=$(cat "$state_file")

--- a/tests/hooks/test-stop-check.sh
+++ b/tests/hooks/test-stop-check.sh
@@ -56,9 +56,13 @@ setup() {
   git -C "$TMPGIT" config user.name "Test"
   touch "$TMPGIT/.gitkeep"
   git -C "$TMPGIT" add .gitkeep
+  write_cfg
+  # Commit config on the default branch BEFORE forking feature/test so that
+  # feature/test does not appear as 1-ahead of main. Tests that need a clean
+  # working tree rely on `git status --porcelain` being empty (HOOK-14).
+  git -C "$TMPGIT" add .silver-bullet.json 2>/dev/null || true
   git -C "$TMPGIT" commit -q -m "init" 2>/dev/null || true
   git -C "$TMPGIT" checkout -q -b feature/test 2>/dev/null || true
-  write_cfg
   export SILVER_BULLET_STATE_FILE="$TMPSTATE"
 }
 
@@ -161,6 +165,10 @@ echo "--- Test 3: Missing skills -> block with skill names ---"
 setup
 # Only put one skill, leaving others missing
 echo "silver-quality-gates" > "$TMPSTATE"
+# Dirty the working tree so HOOK-14 does not short-circuit enforcement
+# (this test validates completion gate behaviour for an actual dev session).
+printf 'work-in-progress\n' > "$TMPDIR_TEST/wip.txt"
+git -C "$TMPDIR_TEST" add wip.txt
 out=$(run_hook)
 assert_blocks "missing skills -> decision:block" "$out"
 assert_contains "block output contains 'code-review'" "$out" "code-review"
@@ -200,6 +208,49 @@ setup
 # Do NOT write anything to the state file — leave it empty/non-existent
 out=$(run_hook)
 assert_passes "empty state file -> non-dev session -> no block" "$out"
+teardown
+
+# Test 7: HOOK-14 — clean tree + no commits ahead + non-empty state -> no block
+# Regression for issue #14: a conversational/read-only session on a branch that
+# carries state from a prior wrap-up should not be gated by completion skills.
+echo "--- Test 7: HOOK-14 clean tree + no ahead commits -> no block ---"
+setup
+# Non-empty state with only one skill — would normally block (missing many)
+echo "silver-quality-gates" > "$TMPSTATE"
+# Working tree is clean (setup already committed .gitkeep) and branch has no
+# commits ahead of its origin: the test repo has no upstream, no origin/main,
+# no main (we are on feature/test). HOOK-14 should still treat this as a
+# conversational session since the tree is clean and there's no comparison ref
+# → nothing to deploy → skip.
+out=$(run_hook)
+assert_passes "clean tree + non-empty state -> conversational session -> no block" "$out"
+teardown
+
+# Test 8: HOOK-14 — dirty working tree + non-empty state + missing skills -> block
+# Guardrail: a session with uncommitted changes should still enforce completion.
+echo "--- Test 8: HOOK-14 dirty tree -> still enforces ---"
+setup
+echo "silver-quality-gates" > "$TMPSTATE"
+# Introduce an uncommitted change so `git diff --quiet` fails
+printf 'dirty\n' > "$TMPDIR_TEST/dirty.txt"
+git -C "$TMPDIR_TEST" add dirty.txt
+out=$(run_hook)
+assert_blocks "dirty tree + missing skills -> still blocks" "$out"
+teardown
+
+# Test 9: HOOK-14 — clean tree + commits ahead of origin -> still enforces
+echo "--- Test 9: HOOK-14 commits ahead of origin -> still enforces ---"
+setup
+# Create a fake origin/main pointing at the initial commit, then add a new
+# commit on feature/test so it's 1 ahead.
+git -C "$TMPDIR_TEST" branch main 2>/dev/null || true
+git -C "$TMPDIR_TEST" update-ref refs/remotes/origin/main "$(git -C "$TMPDIR_TEST" rev-parse HEAD)"
+printf 'more\n' > "$TMPDIR_TEST/more.txt"
+git -C "$TMPDIR_TEST" add more.txt
+git -C "$TMPDIR_TEST" commit -q -m "work" 2>/dev/null || true
+echo "silver-quality-gates" > "$TMPSTATE"
+out=$(run_hook)
+assert_blocks "clean tree but commits ahead -> still blocks" "$out"
 teardown
 
 # ── Results ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Closes #14 — stop-check no longer blocks purely conversational sessions whose state carries over from a prior dev wrap-up.
- Adds HOOK-14 early-exit: if the working tree is clean (no tracked-modified, staged, or untracked files per `git status --porcelain`) AND the branch has no commits ahead of its upstream / origin/main / main, the hook exits silently instead of gating on required_deploy skills.
- Dirty trees and unpushed local commits continue to enforce the completion gate.

## Why
Silver Bullet's completion audit correctly gates *dev* sessions on code-review, testing-strategy, deploy-checklist, silver-create-release, etc. But a session that only answered a question ("which skills does this plugin expose?") was also gated because a previous session's state file carried over to the branch. This fix distinguishes sessions with actual code changes from pure Q&A turns.

## Test plan
- [x] `tests/hooks/test-stop-check.sh` — 10 passed, 0 failed (3 new tests: clean+ahead=0 skips; dirty still blocks; ahead>0 still blocks)
- [x] `tests/run-all-tests.sh` — 976 passed, 13 failed; the 13 are pre-existing baseline failures unrelated to this change (integration tests asserting empty-state blocks conflict with HOOK-04 silent exit). Failure count unchanged vs main.
- [x] setup helper adjusted so `.silver-bullet.json` is committed on the default branch before forking `feature/test`, avoiding false "ahead" detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)