### PR TITLE
chore: gitignore .claude/ runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ site/new/
 *.swo
 .worktrees/
 
+# Claude Code runtime artifacts (per-session locks, worktree state)
+.claude/
+
 # E2E test app -- SB-generated artifacts (excluded from SB repo)
 tests/test-app/node_modules/
 tests/test-app/.planning/


### PR DESCRIPTION
## Summary
- Ignore `.claude/` in the working tree (per-session locks, worktree metadata written by Claude Code)
- Unblocks `/silver-create-release` readiness check, which runs `git status --porcelain`

## Test plan
- [x] `git status --porcelain` is empty after this change in a fresh clone with Claude Code running
- [x] No existing tracked files under `.claude/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)