### PR TITLE
fix(forge-sb): forward-port doc-scheme compliance gate to forge/skills/

### DIFF
--- a/forge/skills/silver-feature/SKILL.md
+++ b/forge/skills/silver-feature/SKILL.md
@@ -46,6 +46,14 @@ Run security quality dimension (trigger: "security"). Write SECURITY.md.
 **PATH 10: QUALITY GATES (pre-ship) [NON-SKIPPABLE]**
 Run all 9 quality dimensions in pre-ship mode. Fix any ❌.
 
+**PATH 10b: DOC-SCHEME COMPLIANCE (conditional)**
+Only if `docs/doc-scheme.md` exists: before raising the PR, verify:
+1. `docs/CHANGELOG.md` — has an entry for this phase (newest-first). Write it if missing.
+2. `docs/ARCHITECTURE.md` — does not say "in progress" for completed phases. Update if stale.
+3. `docs/knowledge/YYYY-MM.md` — append architectural patterns, API gotchas, or key decisions if any.
+4. `docs/lessons/YYYY-MM.md` — append portable lessons learned if any.
+Do NOT proceed to PATH 11 until all four checks pass. If `docs/doc-scheme.md` does not exist, skip this path.
+
 **PATH 11: SHIP**
 Run gsd-ship procedure (trigger: "ship"). Create PR.
 

--- a/forge/skills/writing-plans/SKILL.md
+++ b/forge/skills/writing-plans/SKILL.md
@@ -73,6 +73,13 @@ Arrange tasks in dependency order:
 
 ## Timeline Estimate
 <rough estimate>
+
+## Documentation (if docs/doc-scheme.md exists)
+At finalization, before shipping:
+- docs/CHANGELOG.md — one newest-first entry for this phase
+- docs/ARCHITECTURE.md — update §Current State if architecture changed
+- docs/knowledge/YYYY-MM.md — patterns, gotchas, key decisions
+- docs/lessons/YYYY-MM.md — portable lessons learned
 ```
 
 ### Step 5: Review with Quality Gates


### PR DESCRIPTION
## Summary
- Added PATH 10b doc-scheme compliance gate to `forge/skills/silver-feature/SKILL.md` (between PATH 10 and PATH 11)
- Added `## Documentation` section to the PLAN.md template in `forge/skills/writing-plans/SKILL.md`
- Both additions mirror the gate added in ab6cf0f for the canonical skill variants

## Test Plan
- [x] `bash tests/smoke-test.sh` — 178/178 pass
- [x] Forge format constraints verified (no CC tool names, correct frontmatter)
- [x] Code review: Approved, no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)