### PR TITLE
fix(hooks): add missing required skills to record-skill.sh DEFAULT_TRACKED (#47)

### DIFF
--- a/hooks/record-skill.sh
+++ b/hooks/record-skill.sh
@@ -77,7 +77,7 @@ esac
 # --- Tracked skills list ---
 # GSD command phases (tracked as gsd-* markers for compliance visibility)
 # These are recorded when /gsd:* commands fire via the Skill tool
-DEFAULT_TRACKED="silver-quality-gates silver-blast-radius devops-quality-gates devops-skill-router design-system ux-copy architecture system-design code-review requesting-code-review receiving-code-review testing-strategy documentation finishing-a-development-branch deploy-checklist silver-create-release gsd-new-project gsd-new-milestone gsd-discuss-phase gsd-plan-phase gsd-execute-phase gsd-verify-work gsd-ship gsd-debug gsd-ui-phase gsd-ui-review gsd-secure-phase"
+DEFAULT_TRACKED="silver-quality-gates silver-blast-radius devops-quality-gates devops-skill-router design-system ux-copy architecture system-design code-review requesting-code-review receiving-code-review testing-strategy documentation finishing-a-development-branch deploy-checklist silver-create-release verification-before-completion test-driven-development tech-debt gsd-new-project gsd-new-milestone gsd-discuss-phase gsd-plan-phase gsd-execute-phase gsd-verify-work gsd-ship gsd-debug gsd-ui-phase gsd-ui-review gsd-secure-phase"
 
 tracked_list="$DEFAULT_TRACKED"
 if [[ -n "$config_file" ]]; then


### PR DESCRIPTION
## Summary

\`hooks/record-skill.sh\`'s \`DEFAULT_TRACKED\` was missing \`verification-before-completion\`, \`test-driven-development\`, and \`tech-debt\` — all three are mandated by \`hooks/stop-check.sh\`'s \`DEFAULT_REQUIRED\`. On any project without an explicit \`skills.all_tracked\` override in \`.silver-bullet.json\`, those three skills are never recorded to state, and the stop hook is permanently unsatisfiable.

## Fix

Append the three missing entries immediately after \`silver-create-release\` in \`DEFAULT_TRACKED\`, so the default-config code path matches the default-required set. The \`alo-exp/silver-bullet\` repo itself was only ever working because it ships an explicit \`skills.all_tracked\` override — external consumers without that override were broken.

Fixes #47

## Test plan

- [x] \`bash -n hooks/record-skill.sh\`
- [x] Manually diffed \`DEFAULT_TRACKED\` against \`DEFAULT_REQUIRED\` in \`stop-check.sh\`: tracked now ⊇ required