### PR TITLE
docs(#48): clarify Agent SDK supports hooks via settingSources or programmatic API

### DIFF
--- a/silver-bullet.md
+++ b/silver-bullet.md
@@ -976,6 +976,28 @@ This is the same root cause for the previously open issues #48 and #50. The repo
 2. **Manually record skills in agent-mode sessions.** When forced to run inside an Agent SDK / web session, an agent may invoke each required skill and then explicitly write its name to `~/.claude/.silver-bullet/state` via a Bash command. This is brittle and not recommended for releases.
 3. **Detect agent-mode and refuse delivery actions.** A future SB version may add a startup probe that detects the absence of hook-protocol support and warns / blocks `gh release create` from agent-mode sessions outright. Filed as a follow-up; see the seed file for design constraints.
 
+### Enabling hooks in SDK sessions
+
+The Claude Agent SDK does implement the same hook events SB relies on — `PreToolUse`, `PostToolUse`, `SessionStart`, `Stop`, `SubagentStop`, and others — they are first-class on `HookEvent` in `query()` options. The reason they "do not fire today" in the bullet above is that the SDK does not load `~/.claude/settings.json` unless asked, and does not register programmatic hooks unless passed. Two paths re-enable enforcement inside an SDK session:
+
+1. **Load the user-scoped `~/.claude/settings.json` block** (where `silver:init` writes SB's hook config) by passing `settingSources: ['user']` on `query()` options. An SDK session then picks up the same hook config as the CLI.
+2. **Pass hooks programmatically** on `query()` options:
+
+   ```ts
+   query({
+     prompt: '...',
+     options: {
+       hooks: {
+         PreToolUse: [{ hooks: [async (input) => ({ continue: true })] }],
+       },
+     },
+   })
+   ```
+
+Either path makes SB's enforcement gates fire inside an SDK session. The CLI is still the canonical SB runtime; this is a clarification, not a substitute path.
+
+Reference: `@anthropic-ai/claude-agent-sdk` CHANGELOG documents `settingSources` (initial introduction at v0.1.x) and ongoing fixes for SDK-mode hook delivery (PreToolUse with `permissionDecision: 'ask'`, PermissionRequest, Stop, stream-mode failures). The `claude.ai/code` web UI is a separate runtime and is not addressed here.
+
 ### Detection (advisory)
 
 `silver:init` can probe runtime capability by checking for the presence of the Claude Code hook config (`~/.claude/settings.json`). If absent, it emits an informational warning that enforcement gates will not fire.

--- a/templates/silver-bullet.md.base
+++ b/templates/silver-bullet.md.base
@@ -839,11 +839,13 @@ See `docs/multi-agent-coordination.md` for the full diagram and configuration re
 
 ## 11. Runtime Compatibility
 
-Silver Bullet's enforcement is built on the Claude Code hook protocol (PostToolUse / PreToolUse / SessionStart / Stop / SubagentStop). Hooks fire in the **Claude Code CLI**. They do **not** fire today in the Claude Agent SDK or claude.ai/code web sessions — those runtimes do not invoke the hook protocol.
+Silver Bullet's enforcement is built on the Claude Code hook protocol (PostToolUse / PreToolUse / SessionStart / Stop / SubagentStop). Hooks fire by default in the **Claude Code CLI**. They do **not** fire by default in the Claude Agent SDK or claude.ai/code web sessions.
 
-In those runtimes:
+In those runtimes by default:
 - Skills are not recorded to state (PostToolUse/Skill does not fire)
 - `gh release create` / `gh pr create` / `deploy` are not gated (PreToolUse/Bash does not fire)
 - `Stop` may still fire and see an empty state, blocking the session
 
-**Workaround:** Run release-class actions from the Claude Code CLI, not from Agent-SDK or web sessions. SB enforcement is advisory in those runtimes until the upstream runtime adds hook support.
+**Enabling hooks in an Agent SDK session.** The SDK does implement these hook events; they are first-class on `HookEvent` in `query()` options. To turn them on, either pass `settingSources: ['user']` to load the same `~/.claude/settings.json` block the CLI uses, or pass `hooks` programmatically on `query()` options. The CLI remains the canonical SB runtime; this is a clarification, not a substitute path. The `claude.ai/code` web UI is a separate runtime and is not addressed here.
+
+**Workaround for unenabled SDK / web sessions:** Run release-class actions from the Claude Code CLI. SB enforcement is advisory in those runtimes until hooks are explicitly enabled.


### PR DESCRIPTION
## What

Additive clarification to §12 of `silver-bullet.md` and §11 of `templates/silver-bullet.md.base`. Both sections currently read "hooks do not fire today in the Claude Agent SDK", which understates SDK capability and could discourage SDK consumers from enabling SB enforcement when they could.

## Why

The Claude Agent SDK does implement the same hook events SB depends on (`PreToolUse`, `PostToolUse`, `SessionStart`, `Stop`, `SubagentStop`, etc.). They're first-class on `HookEvent` in `query()` options. `sdk.d.ts` from `@anthropic-ai/claude-agent-sdk@0.2.119`:

```ts
hooks?: Partial<Record<HookEvent, HookCallbackMatcher[]>>;

export declare type HookEvent =
  'PreToolUse' | 'PostToolUse' | 'PostToolUseFailure' | 'PostToolBatch'
  | 'Notification' | 'UserPromptSubmit' | 'UserPromptExpansion'
  | 'SessionStart' | 'SessionEnd' | 'Stop' | 'StopFailure'
  | 'SubagentStart' | 'SubagentStop' | ... ;
```

Hooks don't fire by default in SDK sessions because:
1. The SDK does not load `~/.claude/settings.json` unless `settingSources: ['user']` is passed.
2. Programmatic hooks aren't registered unless `hooks: {...}` is passed on `query()` options.

The current §12 wording reads as if SDK is fundamentally hook-incapable. That's the source of confusion — SDK consumers think they have no path to SB enforcement, when in fact they have two.

## What this PR adds

1. **`silver-bullet.md` §12** — new "Enabling hooks in SDK sessions" subsection between Workarounds and Detection, naming both paths (`settingSources: ['user']` and programmatic `hooks` on `query()`) with a small TypeScript example. Reference to the SDK CHANGELOG for evidence trail.
2. **`templates/silver-bullet.md.base` §11** — parallel terse clarification: opening line softened to "do not fire by default", new "Enabling hooks in an Agent SDK session" paragraph naming both paths, workaround paragraph re-anchored as "for unenabled SDK / web sessions".

## What this PR is **not**

- Not a reopen of #48. The closure framing (CLI is the canonical SB runtime) stands.
- Not a contradiction. The original "hooks do not fire today" claim is true *by default*; this PR just makes the qualifier explicit and points SDK consumers at the two enable paths.
- Not addressing `claude.ai/code` web UI — that's a separate runtime, called out as out-of-scope in both edits.

## CHANGELOG references (claude-agent-sdk-typescript)

- `settingSources` field introduction — explicit settings control over which filesystem settings to load
- Fix: PreToolUse hooks with `permissionDecision: 'ask'` being ignored in SDK mode
- Fix: PermissionRequest hooks not being executed in SDK mode (e.g., VS Code extension)
- Fix: Stop hooks would not consistently run due to `Stream closed` error
- Fix: Hooks sometimes failing in stream mode

These collectively show the SDK's hook surface is real and actively maintained — the gap is configuration, not capability.

## Verification

- `git diff` is +27 / -3 across the two files, all additive prose + one example block
- Confirmed against `@anthropic-ai/claude-agent-sdk@0.2.119` types (`sdk.d.ts`): both `hooks` parameter on `query()` and `settingSources` field exist on `Options`