### PR TITLE
fix(launch-readiness): v0.43.0 — hook/flow alignment and #222

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "repo": "alo-exp/silver-bullet"
       },
       "description": "Agentic Process Orchestrator for AI-native Software Engineering & DevOps. Provides SB-owned lifecycle workflows, optional extension-plugin boundaries, and layered technical compliance.",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "author": {
         "name": "Alo Labs",
         "email": "info@alolabs.dev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "silver-bullet",
   "description": "Agentic Process Orchestrator for AI-native Software Engineering & DevOps. Provides SB-owned lifecycle workflows, optional extension-plugin boundaries, and layered technical compliance.",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "author": {
     "name": "Alo Labs",
     "email": "info@alolabs.dev"

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "repo": "alo-exp/silver-bullet"
       },
       "description": "Agentic Process Orchestrator for AI-native Software Engineering & DevOps. Provides SB-owned lifecycle workflows, optional extension-plugin boundaries, and layered technical compliance.",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "author": {
         "name": "Alo Labs",
         "email": "info@alolabs.dev"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "silver-bullet",
   "description": "Agentic Process Orchestrator for AI-native Software Engineering & DevOps. Provides SB-owned lifecycle workflows, optional extension-plugin boundaries, and layered technical compliance.",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "author": {
     "name": "Alo Labs",
     "email": "info@alolabs.dev"

--- a/.silver-bullet.json
+++ b/.silver-bullet.json
@@ -1,6 +1,6 @@
 {
-  "config_version": "0.42.0",
-  "version": "0.41.0",
+  "config_version": "0.43.0",
+  "version": "0.43.0",
   "sb_initiated": true,
   "project": {
     "name": "silver-bullet",
@@ -57,7 +57,6 @@
       "silver-review-triage",
       "silver-branch-finish",
       "silver-completion-audit",
-      "tdd",
       "verify-tests"
     ],
     "required_release_devops": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [0.43.0] — 2026-06-15
+
+Launch-readiness follow-up: closes GitHub #222 and remaining adversarial review wiring gaps (SB-REV-001–021).
+
+## Bug Fixes
+- `fix(dev-cycle-check): allow rm/rmdir of uninstalled plugin cache dirs when absent from installed_plugins.json` (#222)
+- `fix(completion-audit): wire required_deploy_devops when active_workflow is devops-cycle or composer is silver-devops`
+- `fix(uat-gate): restrict UAT gate to silver:release — phase ship no longer requires UAT.md when SPEC exists`
+- `fix(workflow-chain-guard): scope multi-workflow deadlock to SB_WORKFLOW_ID when set`
+
+## Features / Flows
+- `feat(flows): add silver:completion-audit before ship in feature/ui/devops/bugfix/release compositions`
+- `feat(silver-devops): activate active_workflow devops-cycle at workflow start`
+- `feat(silver-bugfix): complete deploy chain with validate, branch-finish, completion-audit`
+- `fix(silver-ui): canonical security → silver:secure order`
+- `fix(silver-feature): remove stale VERIFY skip from composition context scan`
+- `fix(silver-research): align workflow-chain guard with clarify + research markers`
+
+## Config / Docs
+- `chore(config): remove tdd from required_deploy_devops; align config_version and version to 0.43.0`
+- `docs(ORCHESTRATOR): clarify worker skill invoke vs parent Task spawn; subagent recording note`
+- `fix(silver-update): document Codex registry key silver-bullet@alo-labs-codex`
+
+## Tests
+- Plugin uninstall bypass, devops deploy list, UAT ship scope, multi-workflow SB_WORKFLOW_ID scoping
+
+---
+
 ## [0.42.0] — 2026-06-15
 
 Launch-hardening release. Remediates all blocker/high/medium findings from the pre-launch adversarial review and confirms a clean surface over two consecutive fully-green test rounds (3371 passed, 0 failed; 33/33 hooks covered).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Silver Bullet
 
-[![version](https://img.shields.io/badge/version-v0.42.0-blue)](https://github.com/alo-exp/silver-bullet/releases/tag/v0.42.0)
+[![version](https://img.shields.io/badge/version-v0.43.0-blue)](https://github.com/alo-exp/silver-bullet/releases/tag/v0.43.0)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
 **Agentic Process Orchestrator for AI-native Software Engineering and DevOps.**
@@ -514,8 +514,8 @@ runtime state are not treated as plugin package content.
 
 ## Current Release
 
-- Version: `0.42.0`
-- Release: [v0.42.0](https://github.com/alo-exp/silver-bullet/releases/tag/v0.42.0)
+- Version: `0.43.0`
+- Release: [v0.43.0](https://github.com/alo-exp/silver-bullet/releases/tag/v0.43.0)
 - Notable changes:
   - Template `config_version` aligned to `0.41.0` for orchestrator-parent-mode schema.
   - Cursor `cursor-hooks.json` regenerated for `flow-advance` and `industry-tooling-hint` hook parity.

--- a/agents/claude/silver-bugfix/SKILL.md
+++ b/agents/claude/silver-bugfix/SKILL.md
@@ -60,7 +60,7 @@ Display the composition proposal to the user:
 
 ```
 SILVER BULLET ► FLOW COMPOSED
-Flows: ORIENT → DEBUG → PLAN → EXECUTE → REVIEW → VERIFY → SECURE → SHIP
+Flows: ORIENT → DEBUG → PLAN → EXECUTE → REVIEW → VERIFY → SECURITY → SECURE → VALIDATE → QUALITY GATE → BRANCH-FINISH → COMPLETION-AUDIT → SHIP
 Skipped: BOOTSTRAP — .planning/ exists
 ```
 
@@ -223,7 +223,7 @@ Invoke `silver:verify` through the active runtime's SB-recognized skill invocati
 
 Invoke `security` through the active runtime's SB-recognized skill invocation channel. Non-skippable. Then invoke `silver:secure` for retroactive threat-mitigation verification — both `security` and `silver-secure` are part of `required_deploy`, so the completion-audit deploy gate blocks ship until both are recorded.
 
-> **Canonical post-execution order:** review (Step 5) → verify (Step 6) → security + secure (Step 7) → pre-ship quality gates (Step 7b) → ship (Step 8). This sequence matches `silver:feature`, `silver:ui`, and `silver:devops`.
+> **Canonical post-execution order:** review (Step 5) → verify (Step 6) → security + secure (Step 7) → quality gates (Step 7b) → validate (Step 7c) → branch-finish (Step 7d) → completion-audit (Step 7e) → ship (Step 8). This sequence matches `silver:feature`, `silver:ui`, and `silver:devops`.
 
 ## Step 7a: Tech Debt Review
 
@@ -248,7 +248,19 @@ Skill(skill="silver:add", args="<description of deferred item>")
 
 Invoke `silver:quality-gates` through the active runtime's SB-recognized skill invocation channel (affected quality dimensions for the changed code). Non-skippable.
 
-## Step 7c: Doc-Scheme Compliance (conditional)
+## Step 7c: Validate Phase
+
+Invoke `silver:validate` through the active runtime's SB-recognized skill invocation channel. Purpose: pre-ship validation gap filling and consistency check.
+
+## Step 7d: Finishing Branch
+
+On non-main branches, invoke `silver:branch-finish` through the active runtime's SB-recognized skill invocation channel before ship.
+
+## Step 7e: Completion Audit
+
+Invoke `silver:completion-audit` through the active runtime's SB-recognized skill invocation channel immediately before ship. Purpose: verify completion claims and evidence are substantive — required by `required_deploy` and must be recorded before `gh pr create`.
+
+## Step 7f: Doc-Scheme Compliance (conditional)
 
 **Only if `docs/doc-scheme.md` exists in the project:**
 

--- a/agents/claude/silver-devops/SKILL.md
+++ b/agents/claude/silver-devops/SKILL.md
@@ -36,6 +36,19 @@ Change: {$ARGUMENTS or "(not specified)"}
 Mode:   {interactive | autonomous — from §10e or session selection}
 ```
 
+### Activate devops-cycle enforcement profile
+
+At workflow start, set the project enforcement profile so hooks use `required_deploy_devops` and DevOps planning gates:
+
+```bash
+if [[ -f .silver-bullet.json ]] && command -v jq >/dev/null 2>&1; then
+  tmp="$(mktemp)"
+  jq '.project.active_workflow = "devops-cycle"' .silver-bullet.json > "$tmp" && mv "$tmp" .silver-bullet.json
+fi
+```
+
+This must run before the first planning skill so `completion-audit.sh` and `dev-cycle-check.sh` apply the DevOps skill lists.
+
 ## Composition Proposal
 
 Before beginning execution, read existing artifacts to determine context and propose which flows to include or skip.
@@ -261,6 +274,8 @@ If `docs/doc-scheme.md`/`docs/doc-scheme.json` are missing, recover via `/silver
 ## Step 11: Ship / Deploy
 
 Invoke `silver:ship` through the active runtime's SB-recognized skill invocation channel. Purpose: push branch, deploy, create PR.
+
+Before ship, invoke `silver:branch-finish` on feature branches and `silver:completion-audit` immediately before `silver:ship` (both are in `required_deploy_devops`).
 
 If this workflow performs or prepares an environment rollout, invoke
 `silver:deploy` before or inside ship according to the release plan. The deploy

--- a/agents/claude/silver-fast/SKILL.md
+++ b/agents/claude/silver-fast/SKILL.md
@@ -67,6 +67,8 @@ Make the small edit directly in the current session. Keep the change to the clas
 
 After the trivial edit and verification complete, run scope expansion check (Step 4).
 
+**Tier 1 discipline:** Do not misclassify logic changes as trivial to bypass workflow tracking. The `$HOME/.claude/.silver-bullet/trivial` marker only applies to genuine typo/config-only sessions; any src logic change requires Tier 2+ or `silver:feature`.
+
 If scope remained ≤3 files, display completion banner:
 
 ```

--- a/agents/claude/silver-feature/SKILL.md
+++ b/agents/claude/silver-feature/SKILL.md
@@ -37,7 +37,8 @@ After implementation, final delivery requires the post-execution chain. **Canoni
 5. `silver:validate`
 6. `silver:quality-gates` (pre-ship sweep)
 7. `silver:branch-finish` on feature branches
-8. `silver:ship`
+8. `silver:completion-audit` immediately before ship
+9. `silver:ship`
 
 If any required SB skill cannot be invoked, stop immediately and notify the user. Do not replace missing lifecycle skills with shell-only work, direct edits, or weaker fallback work.
 
@@ -72,7 +73,6 @@ Check the following artifacts and set skip/include flags:
 |----------|--------|--------|
 | `.planning/SPEC.md` exists | Specification already written | Skip FLOW 5 (SPECIFY) |
 | `.planning/PLAN.md` files exist for current phase | Planning already done | Skip FLOW 6 (PLAN) |
-| `.planning/VERIFICATION.md` exists, passing, and newer than last src change | Verification already done | Skip FLOW 12 (VERIFY) |
 | UI files detected in phase scope (*.tsx, *.css, *.html, design/) | UI work in scope | Include FLOW 7 (DESIGN CONTRACT) and FLOW 9 (UI QUALITY) |
 | `STATE.md` current phase and completion status | Phase position | Set loop start/end |
 
@@ -82,20 +82,6 @@ grep "^current_phase\|^current_plan" .planning/STATE.md 2>/dev/null
 
 # Check for existing SPEC.md
 [ -f ".planning/SPEC.md" ] && echo "SPEC exists — skip FLOW 5" || echo "No SPEC — include FLOW 5"
-
-# Check for stale verification (invalidate skip when src changed after VERIFICATION.md)
-if [ -f ".planning/VERIFICATION.md" ]; then
-  src_pattern=$(jq -r '.project.src_pattern // "/src/"' .silver-bullet.json 2>/dev/null || echo "/src/")
-  if find . -type f 2>/dev/null | grep -qE "$src_pattern"; then
-    ver_mtime=$(stat -f %m .planning/VERIFICATION.md 2>/dev/null || stat -c %Y .planning/VERIFICATION.md 2>/dev/null || echo 0)
-    newer_src=$(find . -type f 2>/dev/null | grep -E "$src_pattern" | while read -r f; do
-      stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0
-    done | awk -v v="$ver_mtime" '$1 > v { found=1; exit } END { exit !found }')
-    if [ "${newer_src:-1}" -eq 0 ]; then
-      echo "VERIFICATION.md is stale relative to src changes — include FLOW 12 (VERIFY)"
-    fi
-  fi
-fi
 
 # Check ROADMAP.md for remaining phases in milestone
 grep "^\-\s\[\s\]" .planning/ROADMAP.md 2>/dev/null | head -5
@@ -456,6 +442,10 @@ If `docs/doc-scheme.md`/`docs/doc-scheme.json` are missing, recover via `/silver
 ## Step 14: Finishing Branch
 
 Invoke `silver:branch-finish` through the active runtime's SB-recognized skill invocation channel. Purpose: merge / PR / cleanup decision, branch hygiene, and gate readiness.
+
+## Step 14b: Completion Audit
+
+Invoke `silver:completion-audit` through the active runtime's SB-recognized skill invocation channel immediately before ship. Purpose: verify completion claims and evidence — required by `required_deploy` and must be recorded before `gh pr create`.
 
 ## Step 15a: PR Branch (ask user)
 

--- a/agents/claude/silver-orchestrator/SKILL.md
+++ b/agents/claude/silver-orchestrator/SKILL.md
@@ -57,7 +57,7 @@ When spawning Task, include:
 
 ## Composer specs
 
-`silver-feature`, `silver-ui`, `silver-devops`, `silver-bugfix`, `silver-research`, `silver-fast` are **queue builders** — parent invokes them only to seed `orchestrator.json` / `workflows.sh`, then runs atoms via workers.
+`silver-feature`, `silver-ui`, `silver-devops`, `silver-bugfix`, `silver-research`, `silver-fast` are **queue builders** — parent invokes them only to seed `orchestrator.json` / `workflows.sh`, then runs atoms via workers. On tier-2 hosts, composer specs describe worker prompts; the parent never invokes flow-atom skills directly.
 
 ## Overrides
 

--- a/agents/claude/silver-release/SKILL.md
+++ b/agents/claude/silver-release/SKILL.md
@@ -331,6 +331,8 @@ session.
 Then invoke `silver:verify` for release-scope evidence review. Do not proceed to
 ship until both gates have fresh passing evidence.
 
+Invoke `silver:completion-audit` immediately before `silver:ship` to verify release-scope completion claims.
+
 ## Step 10: Ship - Branch, PR, CI, Deploy Readiness
 
 Invoke `silver:ship`. Purpose: complete phase-level shipping duties before the

--- a/agents/claude/silver-ui/SKILL.md
+++ b/agents/claude/silver-ui/SKILL.md
@@ -254,9 +254,13 @@ Invoke `silver:verify` through the active runtime's SB-recognized skill invocati
 
 **Fresh test execution (required before delivery):** Invoke `verify-tests` to run the project's test gate and record the freshness marker — it is part of `required_deploy`, so the completion-audit deploy gate blocks delivery until a fresh run is recorded. If coverage gaps remain after verification, route a test-gap task through `silver:execute`, then re-run `verify-tests`.
 
-## Step 11: Frontend Security
+## Step 11: Security Review
 
-Invoke `silver:secure` through the active runtime's SB-recognized skill invocation channel. Purpose: frontend security review — XSS, CSP, auth surface. Also invoke `security` as the mandatory security gate.
+Invoke `security` through the active runtime's SB-recognized skill invocation channel. Non-skippable gate.
+
+## Step 11b: Secure Phase
+
+Invoke `silver:secure` through the active runtime's SB-recognized skill invocation channel. Purpose: retroactive threat-mitigation verification and frontend security artifact update (XSS, CSP, auth surface).
 
 ## Step 12: Validate Phase
 
@@ -308,6 +312,10 @@ If `docs/doc-scheme.md`/`docs/doc-scheme.json` are missing, recover via `/silver
 ## Step 14: Finishing Branch
 
 Invoke `silver:branch-finish` through the active runtime's SB-recognized skill invocation channel.
+
+## Step 14b: Completion Audit
+
+Invoke `silver:completion-audit` through the active runtime's SB-recognized skill invocation channel immediately before ship.
 
 Ask user about PR branch:
 > Would you like a clean PR branch (strips .planning/ commits)?

--- a/agents/claude/silver-update/SKILL.md
+++ b/agents/claude/silver-update/SKILL.md
@@ -12,10 +12,13 @@ Check GitHub for the latest Silver Bullet release, display what changed since yo
 
 ### Step 1: Read installed version
 
-Read `$HOME/.claude/plugins/installed_plugins.json`. Try the `silver-bullet@alo-labs` key first; if absent, fall back to the `silver-bullet@silver-bullet` key (legacy installation):
+Read `$HOME/.claude/plugins/installed_plugins.json`. Try these keys in order:
 
-- `version` — currently installed version (e.g. `0.24.1`)
-- If neither key exists, treat installed version as `0.0.0`.
+- `silver-bullet@alo-labs` (Claude / Cursor marketplace)
+- `silver-bullet@alo-labs-codex` (Codex marketplace)
+- `silver-bullet@silver-bullet` (legacy installation)
+
+Use the first key that exists; read its `version` field (e.g. `0.24.1`). If none exist, treat installed version as `0.0.0`.
 
 Display:
 ```

--- a/agents/codex/silver-bugfix/SKILL.md
+++ b/agents/codex/silver-bugfix/SKILL.md
@@ -61,7 +61,7 @@ Display the composition proposal to the user:
 
 ```
 SILVER BULLET ► FLOW COMPOSED
-Flows: ORIENT → DEBUG → PLAN → EXECUTE → REVIEW → VERIFY → SECURE → SHIP
+Flows: ORIENT → DEBUG → PLAN → EXECUTE → REVIEW → VERIFY → SECURITY → SECURE → VALIDATE → QUALITY GATE → BRANCH-FINISH → COMPLETION-AUDIT → SHIP
 Skipped: BOOTSTRAP — .planning/ exists
 ```
 
@@ -224,7 +224,7 @@ Invoke `silver:verify` through the active runtime's SB-recognized skill invocati
 
 Invoke `security` through the active runtime's SB-recognized skill invocation channel. Non-skippable. Then invoke `silver:secure` for retroactive threat-mitigation verification — both `security` and `silver-secure` are part of `required_deploy`, so the completion-audit deploy gate blocks ship until both are recorded.
 
-> **Canonical post-execution order:** review (Step 5) → verify (Step 6) → security + secure (Step 7) → pre-ship quality gates (Step 7b) → ship (Step 8). This sequence matches `silver:feature`, `silver:ui`, and `silver:devops`.
+> **Canonical post-execution order:** review (Step 5) → verify (Step 6) → security + secure (Step 7) → quality gates (Step 7b) → validate (Step 7c) → branch-finish (Step 7d) → completion-audit (Step 7e) → ship (Step 8). This sequence matches `silver:feature`, `silver:ui`, and `silver:devops`.
 
 ## Step 7a: Tech Debt Review
 
@@ -249,7 +249,19 @@ Skill(skill="silver:add", args="<description of deferred item>")
 
 Invoke `silver:quality-gates` through the active runtime's SB-recognized skill invocation channel (affected quality dimensions for the changed code). Non-skippable.
 
-## Step 7c: Doc-Scheme Compliance (conditional)
+## Step 7c: Validate Phase
+
+Invoke `silver:validate` through the active runtime's SB-recognized skill invocation channel. Purpose: pre-ship validation gap filling and consistency check.
+
+## Step 7d: Finishing Branch
+
+On non-main branches, invoke `silver:branch-finish` through the active runtime's SB-recognized skill invocation channel before ship.
+
+## Step 7e: Completion Audit
+
+Invoke `silver:completion-audit` through the active runtime's SB-recognized skill invocation channel immediately before ship. Purpose: verify completion claims and evidence are substantive — required by `required_deploy` and must be recorded before `gh pr create`.
+
+## Step 7f: Doc-Scheme Compliance (conditional)
 
 **Only if `docs/doc-scheme.md` exists in the project:**
 

--- a/agents/codex/silver-devops/SKILL.md
+++ b/agents/codex/silver-devops/SKILL.md
@@ -37,6 +37,19 @@ Change: {$ARGUMENTS or "(not specified)"}
 Mode:   {interactive | autonomous — from §10e or session selection}
 ```
 
+### Activate devops-cycle enforcement profile
+
+At workflow start, set the project enforcement profile so hooks use `required_deploy_devops` and DevOps planning gates:
+
+```bash
+if [[ -f .silver-bullet.json ]] && command -v jq >/dev/null 2>&1; then
+  tmp="$(mktemp)"
+  jq '.project.active_workflow = "devops-cycle"' .silver-bullet.json > "$tmp" && mv "$tmp" .silver-bullet.json
+fi
+```
+
+This must run before the first planning skill so `completion-audit.sh` and `dev-cycle-check.sh` apply the DevOps skill lists.
+
 ## Composition Proposal
 
 Before beginning execution, read existing artifacts to determine context and propose which flows to include or skip.
@@ -262,6 +275,8 @@ If `docs/doc-scheme.md`/`docs/doc-scheme.json` are missing, recover via `/silver
 ## Step 11: Ship / Deploy
 
 Invoke `silver:ship` through the active runtime's SB-recognized skill invocation channel. Purpose: push branch, deploy, create PR.
+
+Before ship, invoke `silver:branch-finish` on feature branches and `silver:completion-audit` immediately before `silver:ship` (both are in `required_deploy_devops`).
 
 If this workflow performs or prepares an environment rollout, invoke
 `silver:deploy` before or inside ship according to the release plan. The deploy

--- a/agents/codex/silver-fast/SKILL.md
+++ b/agents/codex/silver-fast/SKILL.md
@@ -68,6 +68,8 @@ Make the small edit directly in the current session. Keep the change to the clas
 
 After the trivial edit and verification complete, run scope expansion check (Step 4).
 
+**Tier 1 discipline:** Do not misclassify logic changes as trivial to bypass workflow tracking. The `$HOME/.codex/.silver-bullet/trivial` marker only applies to genuine typo/config-only sessions; any src logic change requires Tier 2+ or `silver:feature`.
+
 If scope remained ≤3 files, display completion banner:
 
 ```

--- a/agents/codex/silver-feature/SKILL.md
+++ b/agents/codex/silver-feature/SKILL.md
@@ -38,7 +38,8 @@ After implementation, final delivery requires the post-execution chain. **Canoni
 5. `silver:validate`
 6. `silver:quality-gates` (pre-ship sweep)
 7. `silver:branch-finish` on feature branches
-8. `silver:ship`
+8. `silver:completion-audit` immediately before ship
+9. `silver:ship`
 
 If any required SB skill cannot be invoked, stop immediately and notify the user. Do not replace missing lifecycle skills with shell-only work, direct edits, or weaker fallback work.
 
@@ -73,7 +74,6 @@ Check the following artifacts and set skip/include flags:
 |----------|--------|--------|
 | `.planning/SPEC.md` exists | Specification already written | Skip FLOW 5 (SPECIFY) |
 | `.planning/PLAN.md` files exist for current phase | Planning already done | Skip FLOW 6 (PLAN) |
-| `.planning/VERIFICATION.md` exists, passing, and newer than last src change | Verification already done | Skip FLOW 12 (VERIFY) |
 | UI files detected in phase scope (*.tsx, *.css, *.html, design/) | UI work in scope | Include FLOW 7 (DESIGN CONTRACT) and FLOW 9 (UI QUALITY) |
 | `STATE.md` current phase and completion status | Phase position | Set loop start/end |
 
@@ -83,20 +83,6 @@ grep "^current_phase\|^current_plan" .planning/STATE.md 2>/dev/null
 
 # Check for existing SPEC.md
 [ -f ".planning/SPEC.md" ] && echo "SPEC exists — skip FLOW 5" || echo "No SPEC — include FLOW 5"
-
-# Check for stale verification (invalidate skip when src changed after VERIFICATION.md)
-if [ -f ".planning/VERIFICATION.md" ]; then
-  src_pattern=$(jq -r '.project.src_pattern // "/src/"' .silver-bullet.json 2>/dev/null || echo "/src/")
-  if find . -type f 2>/dev/null | grep -qE "$src_pattern"; then
-    ver_mtime=$(stat -f %m .planning/VERIFICATION.md 2>/dev/null || stat -c %Y .planning/VERIFICATION.md 2>/dev/null || echo 0)
-    newer_src=$(find . -type f 2>/dev/null | grep -E "$src_pattern" | while read -r f; do
-      stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0
-    done | awk -v v="$ver_mtime" '$1 > v { found=1; exit } END { exit !found }')
-    if [ "${newer_src:-1}" -eq 0 ]; then
-      echo "VERIFICATION.md is stale relative to src changes — include FLOW 12 (VERIFY)"
-    fi
-  fi
-fi
 
 # Check ROADMAP.md for remaining phases in milestone
 grep "^\-\s\[\s\]" .planning/ROADMAP.md 2>/dev/null | head -5
@@ -457,6 +443,10 @@ If `docs/doc-scheme.md`/`docs/doc-scheme.json` are missing, recover via `/silver
 ## Step 14: Finishing Branch
 
 Invoke `silver:branch-finish` through the active runtime's SB-recognized skill invocation channel. Purpose: merge / PR / cleanup decision, branch hygiene, and gate readiness.
+
+## Step 14b: Completion Audit
+
+Invoke `silver:completion-audit` through the active runtime's SB-recognized skill invocation channel immediately before ship. Purpose: verify completion claims and evidence — required by `required_deploy` and must be recorded before `gh pr create`.
 
 ## Step 15a: PR Branch (ask user)
 

--- a/agents/codex/silver-orchestrator/SKILL.md
+++ b/agents/codex/silver-orchestrator/SKILL.md
@@ -58,7 +58,7 @@ When spawning Task, include:
 
 ## Composer specs
 
-`silver-feature`, `silver-ui`, `silver-devops`, `silver-bugfix`, `silver-research`, `silver-fast` are **queue builders** — parent invokes them only to seed `orchestrator.json` / `workflows.sh`, then runs atoms via workers.
+`silver-feature`, `silver-ui`, `silver-devops`, `silver-bugfix`, `silver-research`, `silver-fast` are **queue builders** — parent invokes them only to seed `orchestrator.json` / `workflows.sh`, then runs atoms via workers. On tier-2 hosts, composer specs describe worker prompts; the parent never invokes flow-atom skills directly.
 
 ## Overrides
 

--- a/agents/codex/silver-release/SKILL.md
+++ b/agents/codex/silver-release/SKILL.md
@@ -332,6 +332,8 @@ session.
 Then invoke `silver:verify` for release-scope evidence review. Do not proceed to
 ship until both gates have fresh passing evidence.
 
+Invoke `silver:completion-audit` immediately before `silver:ship` to verify release-scope completion claims.
+
 ## Step 10: Ship - Branch, PR, CI, Deploy Readiness
 
 Invoke `silver:ship`. Purpose: complete phase-level shipping duties before the

--- a/agents/codex/silver-ui/SKILL.md
+++ b/agents/codex/silver-ui/SKILL.md
@@ -255,9 +255,13 @@ Invoke `silver:verify` through the active runtime's SB-recognized skill invocati
 
 **Fresh test execution (required before delivery):** Invoke `verify-tests` to run the project's test gate and record the freshness marker — it is part of `required_deploy`, so the completion-audit deploy gate blocks delivery until a fresh run is recorded. If coverage gaps remain after verification, route a test-gap task through `silver:execute`, then re-run `verify-tests`.
 
-## Step 11: Frontend Security
+## Step 11: Security Review
 
-Invoke `silver:secure` through the active runtime's SB-recognized skill invocation channel. Purpose: frontend security review — XSS, CSP, auth surface. Also invoke `security` as the mandatory security gate.
+Invoke `security` through the active runtime's SB-recognized skill invocation channel. Non-skippable gate.
+
+## Step 11b: Secure Phase
+
+Invoke `silver:secure` through the active runtime's SB-recognized skill invocation channel. Purpose: retroactive threat-mitigation verification and frontend security artifact update (XSS, CSP, auth surface).
 
 ## Step 12: Validate Phase
 
@@ -309,6 +313,10 @@ If `docs/doc-scheme.md`/`docs/doc-scheme.json` are missing, recover via `/silver
 ## Step 14: Finishing Branch
 
 Invoke `silver:branch-finish` through the active runtime's SB-recognized skill invocation channel.
+
+## Step 14b: Completion Audit
+
+Invoke `silver:completion-audit` through the active runtime's SB-recognized skill invocation channel immediately before ship.
 
 Ask user about PR branch:
 > Would you like a clean PR branch (strips .planning/ commits)?

--- a/agents/codex/silver-update/SKILL.md
+++ b/agents/codex/silver-update/SKILL.md
@@ -13,10 +13,13 @@ Check GitHub for the latest Silver Bullet release, display what changed since yo
 
 ### Step 1: Read installed version
 
-Read `$HOME/.codex/plugins/installed_plugins.json`. Try the `silver-bullet@alo-labs` key first; if absent, fall back to the `silver-bullet@silver-bullet` key (legacy installation):
+Read `$HOME/.codex/plugins/installed_plugins.json`. Try these keys in order:
 
-- `version` — currently installed version (e.g. `0.24.1`)
-- If neither key exists, treat installed version as `0.0.0`.
+- `silver-bullet@alo-labs` (Claude / Cursor marketplace)
+- `silver-bullet@alo-labs-codex` (Codex marketplace)
+- `silver-bullet@silver-bullet` (legacy installation)
+
+Use the first key that exists; read its `version` field (e.g. `0.24.1`). If none exist, treat installed version as `0.0.0`.
 
 Display:
 ```

--- a/agents/cursor/silver-bugfix/SKILL.md
+++ b/agents/cursor/silver-bugfix/SKILL.md
@@ -60,7 +60,7 @@ Display the composition proposal to the user:
 
 ```
 SILVER BULLET ► FLOW COMPOSED
-Flows: ORIENT → DEBUG → PLAN → EXECUTE → REVIEW → VERIFY → SECURE → SHIP
+Flows: ORIENT → DEBUG → PLAN → EXECUTE → REVIEW → VERIFY → SECURITY → SECURE → VALIDATE → QUALITY GATE → BRANCH-FINISH → COMPLETION-AUDIT → SHIP
 Skipped: BOOTSTRAP — .planning/ exists
 ```
 
@@ -223,7 +223,7 @@ Invoke `silver:verify` through the active runtime's SB-recognized skill invocati
 
 Invoke `security` through the active runtime's SB-recognized skill invocation channel. Non-skippable. Then invoke `silver:secure` for retroactive threat-mitigation verification — both `security` and `silver-secure` are part of `required_deploy`, so the completion-audit deploy gate blocks ship until both are recorded.
 
-> **Canonical post-execution order:** review (Step 5) → verify (Step 6) → security + secure (Step 7) → pre-ship quality gates (Step 7b) → ship (Step 8). This sequence matches `silver:feature`, `silver:ui`, and `silver:devops`.
+> **Canonical post-execution order:** review (Step 5) → verify (Step 6) → security + secure (Step 7) → quality gates (Step 7b) → validate (Step 7c) → branch-finish (Step 7d) → completion-audit (Step 7e) → ship (Step 8). This sequence matches `silver:feature`, `silver:ui`, and `silver:devops`.
 
 ## Step 7a: Tech Debt Review
 
@@ -248,7 +248,19 @@ Skill(skill="silver:add", args="<description of deferred item>")
 
 Invoke `silver:quality-gates` through the active runtime's SB-recognized skill invocation channel (affected quality dimensions for the changed code). Non-skippable.
 
-## Step 7c: Doc-Scheme Compliance (conditional)
+## Step 7c: Validate Phase
+
+Invoke `silver:validate` through the active runtime's SB-recognized skill invocation channel. Purpose: pre-ship validation gap filling and consistency check.
+
+## Step 7d: Finishing Branch
+
+On non-main branches, invoke `silver:branch-finish` through the active runtime's SB-recognized skill invocation channel before ship.
+
+## Step 7e: Completion Audit
+
+Invoke `silver:completion-audit` through the active runtime's SB-recognized skill invocation channel immediately before ship. Purpose: verify completion claims and evidence are substantive — required by `required_deploy` and must be recorded before `gh pr create`.
+
+## Step 7f: Doc-Scheme Compliance (conditional)
 
 **Only if `docs/doc-scheme.md` exists in the project:**
 

--- a/agents/cursor/silver-devops/SKILL.md
+++ b/agents/cursor/silver-devops/SKILL.md
@@ -36,6 +36,19 @@ Change: {$ARGUMENTS or "(not specified)"}
 Mode:   {interactive | autonomous — from §10e or session selection}
 ```
 
+### Activate devops-cycle enforcement profile
+
+At workflow start, set the project enforcement profile so hooks use `required_deploy_devops` and DevOps planning gates:
+
+```bash
+if [[ -f .silver-bullet.json ]] && command -v jq >/dev/null 2>&1; then
+  tmp="$(mktemp)"
+  jq '.project.active_workflow = "devops-cycle"' .silver-bullet.json > "$tmp" && mv "$tmp" .silver-bullet.json
+fi
+```
+
+This must run before the first planning skill so `completion-audit.sh` and `dev-cycle-check.sh` apply the DevOps skill lists.
+
 ## Composition Proposal
 
 Before beginning execution, read existing artifacts to determine context and propose which flows to include or skip.
@@ -261,6 +274,8 @@ If `docs/doc-scheme.md`/`docs/doc-scheme.json` are missing, recover via `/silver
 ## Step 11: Ship / Deploy
 
 Invoke `silver:ship` through the active runtime's SB-recognized skill invocation channel. Purpose: push branch, deploy, create PR.
+
+Before ship, invoke `silver:branch-finish` on feature branches and `silver:completion-audit` immediately before `silver:ship` (both are in `required_deploy_devops`).
 
 If this workflow performs or prepares an environment rollout, invoke
 `silver:deploy` before or inside ship according to the release plan. The deploy

--- a/agents/cursor/silver-fast/SKILL.md
+++ b/agents/cursor/silver-fast/SKILL.md
@@ -67,6 +67,8 @@ Make the small edit directly in the current session. Keep the change to the clas
 
 After the trivial edit and verification complete, run scope expansion check (Step 4).
 
+**Tier 1 discipline:** Do not misclassify logic changes as trivial to bypass workflow tracking. The `$HOME/.cursor/.silver-bullet/trivial` marker only applies to genuine typo/config-only sessions; any src logic change requires Tier 2+ or `silver:feature`.
+
 If scope remained ≤3 files, display completion banner:
 
 ```

--- a/agents/cursor/silver-feature/SKILL.md
+++ b/agents/cursor/silver-feature/SKILL.md
@@ -37,7 +37,8 @@ After implementation, final delivery requires the post-execution chain. **Canoni
 5. `silver:validate`
 6. `silver:quality-gates` (pre-ship sweep)
 7. `silver:branch-finish` on feature branches
-8. `silver:ship`
+8. `silver:completion-audit` immediately before ship
+9. `silver:ship`
 
 If any required SB skill cannot be invoked, stop immediately and notify the user. Do not replace missing lifecycle skills with shell-only work, direct edits, or weaker fallback work.
 
@@ -72,7 +73,6 @@ Check the following artifacts and set skip/include flags:
 |----------|--------|--------|
 | `.planning/SPEC.md` exists | Specification already written | Skip FLOW 5 (SPECIFY) |
 | `.planning/PLAN.md` files exist for current phase | Planning already done | Skip FLOW 6 (PLAN) |
-| `.planning/VERIFICATION.md` exists, passing, and newer than last src change | Verification already done | Skip FLOW 12 (VERIFY) |
 | UI files detected in phase scope (*.tsx, *.css, *.html, design/) | UI work in scope | Include FLOW 7 (DESIGN CONTRACT) and FLOW 9 (UI QUALITY) |
 | `STATE.md` current phase and completion status | Phase position | Set loop start/end |
 
@@ -82,20 +82,6 @@ grep "^current_phase\|^current_plan" .planning/STATE.md 2>/dev/null
 
 # Check for existing SPEC.md
 [ -f ".planning/SPEC.md" ] && echo "SPEC exists — skip FLOW 5" || echo "No SPEC — include FLOW 5"
-
-# Check for stale verification (invalidate skip when src changed after VERIFICATION.md)
-if [ -f ".planning/VERIFICATION.md" ]; then
-  src_pattern=$(jq -r '.project.src_pattern // "/src/"' .silver-bullet.json 2>/dev/null || echo "/src/")
-  if find . -type f 2>/dev/null | grep -qE "$src_pattern"; then
-    ver_mtime=$(stat -f %m .planning/VERIFICATION.md 2>/dev/null || stat -c %Y .planning/VERIFICATION.md 2>/dev/null || echo 0)
-    newer_src=$(find . -type f 2>/dev/null | grep -E "$src_pattern" | while read -r f; do
-      stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0
-    done | awk -v v="$ver_mtime" '$1 > v { found=1; exit } END { exit !found }')
-    if [ "${newer_src:-1}" -eq 0 ]; then
-      echo "VERIFICATION.md is stale relative to src changes — include FLOW 12 (VERIFY)"
-    fi
-  fi
-fi
 
 # Check ROADMAP.md for remaining phases in milestone
 grep "^\-\s\[\s\]" .planning/ROADMAP.md 2>/dev/null | head -5
@@ -456,6 +442,10 @@ If `docs/doc-scheme.md`/`docs/doc-scheme.json` are missing, recover via `/silver
 ## Step 14: Finishing Branch
 
 Invoke `silver:branch-finish` through the active runtime's SB-recognized skill invocation channel. Purpose: merge / PR / cleanup decision, branch hygiene, and gate readiness.
+
+## Step 14b: Completion Audit
+
+Invoke `silver:completion-audit` through the active runtime's SB-recognized skill invocation channel immediately before ship. Purpose: verify completion claims and evidence — required by `required_deploy` and must be recorded before `gh pr create`.
 
 ## Step 15a: PR Branch (ask user)
 

--- a/agents/cursor/silver-orchestrator/SKILL.md
+++ b/agents/cursor/silver-orchestrator/SKILL.md
@@ -57,7 +57,7 @@ When spawning Task, include:
 
 ## Composer specs
 
-`silver-feature`, `silver-ui`, `silver-devops`, `silver-bugfix`, `silver-research`, `silver-fast` are **queue builders** — parent invokes them only to seed `orchestrator.json` / `workflows.sh`, then runs atoms via workers.
+`silver-feature`, `silver-ui`, `silver-devops`, `silver-bugfix`, `silver-research`, `silver-fast` are **queue builders** — parent invokes them only to seed `orchestrator.json` / `workflows.sh`, then runs atoms via workers. On tier-2 hosts, composer specs describe worker prompts; the parent never invokes flow-atom skills directly.
 
 ## Overrides
 

--- a/agents/cursor/silver-release/SKILL.md
+++ b/agents/cursor/silver-release/SKILL.md
@@ -331,6 +331,8 @@ session.
 Then invoke `silver:verify` for release-scope evidence review. Do not proceed to
 ship until both gates have fresh passing evidence.
 
+Invoke `silver:completion-audit` immediately before `silver:ship` to verify release-scope completion claims.
+
 ## Step 10: Ship - Branch, PR, CI, Deploy Readiness
 
 Invoke `silver:ship`. Purpose: complete phase-level shipping duties before the

--- a/agents/cursor/silver-ui/SKILL.md
+++ b/agents/cursor/silver-ui/SKILL.md
@@ -254,9 +254,13 @@ Invoke `silver:verify` through the active runtime's SB-recognized skill invocati
 
 **Fresh test execution (required before delivery):** Invoke `verify-tests` to run the project's test gate and record the freshness marker — it is part of `required_deploy`, so the completion-audit deploy gate blocks delivery until a fresh run is recorded. If coverage gaps remain after verification, route a test-gap task through `silver:execute`, then re-run `verify-tests`.
 
-## Step 11: Frontend Security
+## Step 11: Security Review
 
-Invoke `silver:secure` through the active runtime's SB-recognized skill invocation channel. Purpose: frontend security review — XSS, CSP, auth surface. Also invoke `security` as the mandatory security gate.
+Invoke `security` through the active runtime's SB-recognized skill invocation channel. Non-skippable gate.
+
+## Step 11b: Secure Phase
+
+Invoke `silver:secure` through the active runtime's SB-recognized skill invocation channel. Purpose: retroactive threat-mitigation verification and frontend security artifact update (XSS, CSP, auth surface).
 
 ## Step 12: Validate Phase
 
@@ -308,6 +312,10 @@ If `docs/doc-scheme.md`/`docs/doc-scheme.json` are missing, recover via `/silver
 ## Step 14: Finishing Branch
 
 Invoke `silver:branch-finish` through the active runtime's SB-recognized skill invocation channel.
+
+## Step 14b: Completion Audit
+
+Invoke `silver:completion-audit` through the active runtime's SB-recognized skill invocation channel immediately before ship.
 
 Ask user about PR branch:
 > Would you like a clean PR branch (strips .planning/ commits)?

--- a/agents/cursor/silver-update/SKILL.md
+++ b/agents/cursor/silver-update/SKILL.md
@@ -12,10 +12,13 @@ Check GitHub for the latest Silver Bullet release, display what changed since yo
 
 ### Step 1: Read installed version
 
-Read `$HOME/.cursor/plugins/installed_plugins.json`. Try the `silver-bullet@alo-labs` key first; if absent, fall back to the `silver-bullet@silver-bullet` key (legacy installation):
+Read `$HOME/.cursor/plugins/installed_plugins.json`. Try these keys in order:
 
-- `version` — currently installed version (e.g. `0.24.1`)
-- If neither key exists, treat installed version as `0.0.0`.
+- `silver-bullet@alo-labs` (Claude / Cursor marketplace)
+- `silver-bullet@alo-labs-codex` (Codex marketplace)
+- `silver-bullet@silver-bullet` (legacy installation)
+
+Use the first key that exists; read its `version` field (e.g. `0.24.1`). If none exist, treat installed version as `0.0.0`.
 
 Display:
 ```

--- a/docs/ORCHESTRATOR.md
+++ b/docs/ORCHESTRATOR.md
@@ -9,7 +9,9 @@ Silver Bullet's orchestrator sequences lifecycle work through **directives**, **
 | Role | Session | May implement? | Tools |
 |------|---------|----------------|-------|
 | **Parent** | Main agent / `/silver` | **No** | Task, Read, Grep, Glob; Skill: `silver` / `silver-orchestrator` only |
-| **Worker** | Task subagent per atomic flow | **Yes** (after assigned skill) | Full tool surface per flow contract |
+| **Worker** | Task subagent per atomic flow | **Yes** (after assigned skill) | Full tool surface per flow contract; **invoke** (not merely read) the assigned skill |
+
+On tier-2 hosts the parent **spawns Task workers**; workers **invoke** flow-atom skills so hooks record state. Single-agent hosts without Task/subagent support follow the same skill order but invoke skills directly — see `docs/RUNTIME-COMPATIBILITY.md`.
 
 Config: `"orchestrator_mode": "parent"` (only allowed value; default in template).
 
@@ -80,6 +82,10 @@ Guidance only — `templates/cursor-rules/silver-orchestrator.mdc` + directive i
 
 - **Worker SubagentStop:** Clears `orchestrator-worker-active.json`; does not block (parent continues).
 - **Parent Stop:** Blocked while orchestrator queue has pending `current_flow` — parent must spawn next Task worker.
+
+### Skill recording from workers
+
+Workers must invoke assigned flow skills through the host's SB-recognized channel (`Skill` tool, `scripts/silver-bullet invoke-skill`, or equivalent) so `PostToolUse/Skill` → `record-skill.sh` appends markers to `${SB_RUNTIME_STATE_DIR}/state`. Parent Task spawns do not auto-record skills — the worker invocation does. If delivery gates report missing skills after a worker completed, verify the worker used a recorded channel rather than reading the skill file inline.
 
 ## Migration
 

--- a/hooks/completion-audit.sh
+++ b/hooks/completion-audit.sh
@@ -308,6 +308,7 @@ quality_gate_state_file="${SB_STATE_DIR}/quality-gate-state"
 verify_tests_state_file="${SB_STATE_DIR}/verify-tests-state"
 required_planning_cfg=""
 required_deploy_cfg=""
+required_deploy_devops_cfg=""
 required_planning_devops_cfg=""
 active_workflow="full-dev-cycle"
 release_require_plugin_runtime_matrix="false"
@@ -321,6 +322,7 @@ config_vals=$(jq -r --arg ds "$sb_default_state" --arg dt "$sb_default_trivial" 
   ((.skills.required_planning // []) | join(" ")),
   ((.skills.required_planning_devops // []) | join(" ")),
   ((.skills.required_deploy // []) | join(" ")),
+  ((.skills.required_deploy_devops // []) | join(" ")),
   (.project.active_workflow // "full-dev-cycle"),
   (.release.quality_gate_state_file // ""),
   ((.release.require_plugin_runtime_matrix // false) | tostring),
@@ -334,11 +336,12 @@ trivial_file="${trivial_file/#\~/$HOME}"
 required_planning_cfg=$(printf '%s' "$config_vals" | sed -n '3p')
 required_planning_devops_cfg=$(printf '%s' "$config_vals" | sed -n '4p')
 required_deploy_cfg=$(printf '%s' "$config_vals" | sed -n '5p')
-active_workflow=$(printf '%s' "$config_vals" | sed -n '6p')
-cfg_quality_gate_state_file=$(printf '%s' "$config_vals" | sed -n '7p')
+required_deploy_devops_cfg=$(printf '%s' "$config_vals" | sed -n '6p')
+active_workflow=$(printf '%s' "$config_vals" | sed -n '7p')
+cfg_quality_gate_state_file=$(printf '%s' "$config_vals" | sed -n '8p')
 [[ -n "$cfg_quality_gate_state_file" ]] && quality_gate_state_file="${cfg_quality_gate_state_file/#\~/$HOME}"
-release_require_plugin_runtime_matrix=$(printf '%s' "$config_vals" | sed -n '8p')
-release_require_pre_release_quality_gate=$(printf '%s' "$config_vals" | sed -n '9p')
+release_require_plugin_runtime_matrix=$(printf '%s' "$config_vals" | sed -n '9p')
+release_require_pre_release_quality_gate=$(printf '%s' "$config_vals" | sed -n '10p')
 
 # Env var override for state file
 state_file="${SILVER_BULLET_STATE_FILE:-$state_file}"
@@ -900,8 +903,32 @@ DEFAULT_REQUIRED="${DEFAULT_REQUIRED:-silver-quality-gates silver-review silver-
 DEVOPS_DEFAULT_REQUIRED="${DEVOPS_DEFAULT_REQUIRED:-silver-blast-radius devops-quality-gates silver-review silver-review-request silver-review-triage silver-branch-finish silver-create-release silver-completion-audit silver-tdd verify-tests}"
 
 # DevOps workflow substitutes silver-quality-gates with silver-blast-radius + devops-quality-gates
+delivery_uses_devops_deploy=false
 if [[ "$active_workflow" == "devops-cycle" ]]; then
+  delivery_uses_devops_deploy=true
   DEFAULT_REQUIRED="$DEVOPS_DEFAULT_REQUIRED"
+else
+  project_root_for_composer="$(dirname "$config_file")"
+  [[ -z "$project_root_for_composer" ]] && project_root_for_composer="$PWD"
+  wf_dir_for_composer="$project_root_for_composer/.planning/workflows"
+  composer_wf_id="${SB_WORKFLOW_ID:-}"
+  if [[ -z "$composer_wf_id" ]]; then
+    composer_wf_id="$(workflow_id_from_shell_assignment "$cmd" 2>/dev/null || true)"
+  fi
+  if [[ -n "$composer_wf_id" && -f "$wf_dir_for_composer/$composer_wf_id.md" ]]; then
+    composer_slug_raw="$(awk -F': ' '/^composer: / { print $2; exit }' "$wf_dir_for_composer/$composer_wf_id.md" 2>/dev/null || true)"
+    composer_slug_norm="$(printf '%s' "$composer_slug_raw" | tr '[:upper:]' '[:lower:]' | sed 's|[:/]| |g' | awk '{print $NF}')"
+    if [[ "$composer_slug_norm" == "silver-devops" || "$composer_slug_norm" == "devops" ]]; then
+      delivery_uses_devops_deploy=true
+      DEFAULT_REQUIRED="$DEVOPS_DEFAULT_REQUIRED"
+    fi
+  fi
+fi
+
+if [[ "$delivery_uses_devops_deploy" == true ]]; then
+  if [[ -n "$required_deploy_devops_cfg" ]]; then
+    required_deploy_cfg="$required_deploy_devops_cfg"
+  fi
 fi
 
 # When on main/master branch, branch finishing is not applicable
@@ -925,12 +952,12 @@ fi
 # Release commands also require release-only skills (e.g. silver-create-release).
 if printf '%s' "$cmd_first_line" | grep -qE '\bgh release create\b'; then
   release_defaults="${DEFAULT_RELEASE_REQUIRED:-silver-create-release}"
-  if [[ "$active_workflow" == "devops-cycle" ]]; then
+  if [[ "$delivery_uses_devops_deploy" == true ]]; then
     release_defaults="${DEVOPS_DEFAULT_RELEASE_REQUIRED:-silver-create-release}"
   fi
   release_cfg=""
   if command -v jq >/dev/null 2>&1 && [[ -f "$config_file" ]]; then
-    if [[ "$active_workflow" == "devops-cycle" ]]; then
+    if [[ "$delivery_uses_devops_deploy" == true ]]; then
       release_cfg=$(jq -r '(.skills.required_release_devops // .skills.required_release // []) | join(" ")' "$config_file" 2>/dev/null || true)
     else
       release_cfg=$(jq -r '(.skills.required_release // []) | join(" ")' "$config_file" 2>/dev/null || true)

--- a/hooks/dev-cycle-check.sh
+++ b/hooks/dev-cycle-check.sh
@@ -8,6 +8,10 @@ if [[ -f "$_lib_dir/runtime-paths.sh" ]]; then
   # shellcheck source=lib/runtime-paths.sh
   source "$_lib_dir/runtime-paths.sh"
 fi
+if [[ -f "$_lib_dir/plugin-cache-guard.sh" ]]; then
+  # shellcheck source=lib/plugin-cache-guard.sh
+  source "$_lib_dir/plugin-cache-guard.sh"
+fi
 if [[ -f "$_lib_dir/required-skills.sh" ]]; then
   # shellcheck source=lib/required-skills.sh
   # shellcheck disable=SC1091
@@ -180,6 +184,13 @@ main() {
 
   # --- Third-party plugin boundary (§8) — HARD STOP on upstream plugin edits ---
   plugin_cache="${SB_RUNTIME_PLUGIN_CACHE_ROOT}"
+  plugin_boundary_is_uninstall_cleanup() {
+    if [[ -n "${command_str:-}" ]] && declare -f sb_plugin_cache_command_is_uninstall_cleanup >/dev/null 2>&1; then
+      sb_plugin_cache_command_is_uninstall_cleanup "$command_str" "${shell_write_targets[@]:-}"
+      return $?
+    fi
+    return 1
+  }
   if [[ -n "$file_path" ]] && [[ "$file_path" == "$plugin_cache"/* ]]; then
     msg="🚫 THIRD-PARTY PLUGIN BOUNDARY VIOLATION — You are attempting to edit a file inside the plugin cache:
 $(basename "$file_path")
@@ -196,15 +207,20 @@ See CLAUDE.md §8 for details."
     # F-07: Block Bash commands that write into the plugin cache.
     # Read-only access to upstream templates is allowed so Silver Bullet can
     # copy them into the project workspace during initialization.
+    # Uninstall cleanup is allowed when installed_plugins.json no longer references the path (#222).
     if shell_writes_under_prefix "$plugin_cache"; then
-      emit_block "🚫 THIRD-PARTY PLUGIN BOUNDARY VIOLATION via Bash command — Silver Bullet NEVER modifies upstream plugin files. See CLAUDE.md §8."
-      exit 0
+      if ! plugin_boundary_is_uninstall_cleanup; then
+        emit_block "🚫 THIRD-PARTY PLUGIN BOUNDARY VIOLATION via Bash command — Silver Bullet NEVER modifies upstream plugin files. See CLAUDE.md §8."
+        exit 0
+      fi
     fi
     if printf '%s' "$command_str" | grep -qE "$plugin_cache"; then
       plugin_write_pattern='([[:space:]](>>|>)[[:space:]]*"?'"$plugin_cache"'|\b(cp|mv|rm|chmod|install|tee)\b.*"?'"$plugin_cache"'|\b(sed|perl)\b.*-i.*"?'"$plugin_cache"')'
       if printf '%s' "$command_str" | grep -qE "$plugin_write_pattern"; then
-        emit_block "🚫 THIRD-PARTY PLUGIN BOUNDARY VIOLATION via Bash command — Silver Bullet NEVER modifies upstream plugin files. See CLAUDE.md §8."
-        exit 0
+        if ! plugin_boundary_is_uninstall_cleanup; then
+          emit_block "🚫 THIRD-PARTY PLUGIN BOUNDARY VIOLATION via Bash command — Silver Bullet NEVER modifies upstream plugin files. See CLAUDE.md §8."
+          exit 0
+        fi
       fi
     fi
   fi

--- a/hooks/lib/plugin-cache-guard.sh
+++ b/hooks/lib/plugin-cache-guard.sh
@@ -1,0 +1,98 @@
+# shellcheck shell=bash
+# Allow deliberate third-party plugin uninstall cache cleanup when the host
+# registry no longer references the target path (GitHub issue #222).
+
+sb_plugin_cache_registry_file() {
+  printf '%s/plugins/installed_plugins.json' "${SB_RUNTIME_HOME_ROOT}"
+}
+
+# Print installPath values from installed_plugins.json (one per line).
+sb_plugin_cache_installed_paths() {
+  local registry
+  registry="$(sb_plugin_cache_registry_file)"
+  [[ -f "$registry" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 1
+  jq -r '
+    .plugins // {} | to_entries[] | .value[]? | .installPath // empty
+  ' "$registry" 2>/dev/null
+}
+
+# True when no installed plugin still references this cache path (uninstall cleanup).
+sb_plugin_cache_path_is_uninstalled() {
+  local target="$1"
+  local cache_root="${2:-${SB_RUNTIME_PLUGIN_CACHE_ROOT}}"
+  local install_path normalized_target normalized_install
+
+  [[ -n "$target" && -n "$cache_root" ]] || return 1
+  [[ -f "$(sb_plugin_cache_registry_file)" ]] || return 1
+  cache_root="${cache_root%/}"
+  normalized_target="${target//\/\//\/}"
+
+  case "$normalized_target" in
+    "$cache_root"|"$cache_root"/*) ;;
+    *) return 1 ;;
+  esac
+
+  while IFS= read -r install_path; do
+    [[ -n "$install_path" ]] || continue
+    normalized_install="${install_path/#\~/$HOME}"
+    normalized_install="${normalized_install//\/\//\/}"
+    case "$normalized_install" in
+      "$normalized_target"|"$normalized_target"/*)
+        return 1
+        ;;
+      "$cache_root"|"$cache_root"/*)
+        case "$normalized_target" in
+          "$normalized_install"|"$normalized_install"/*)
+            return 1
+            ;;
+        esac
+        ;;
+    esac
+  done < <(sb_plugin_cache_installed_paths 2>/dev/null || true)
+
+  return 0
+}
+
+# True when the command is deliberate plugin-cache uninstall cleanup (#222).
+# Only deletion-style writes qualify; cp/mv/install/tee/sed-in-place remain blocked.
+sb_plugin_cache_command_is_uninstall_cleanup() {
+  local command_str="$1"
+  local cache_root="${2:-${SB_RUNTIME_PLUGIN_CACHE_ROOT}}"
+  [[ -n "$command_str" && -n "$cache_root" ]] || return 1
+
+  if ! printf '%s' "$command_str" | grep -qE "$cache_root"; then
+    return 1
+  fi
+
+  if ! printf '%s' "$command_str" | grep -qE '\b(rm|rmdir)\b'; then
+    return 1
+  fi
+
+  declare -f sb_plugin_cache_writes_are_uninstall_cleanup >/dev/null 2>&1 || return 1
+  sb_plugin_cache_writes_are_uninstall_cleanup "$@"
+}
+
+# True when every write target under the plugin cache is uninstall cleanup.
+sb_plugin_cache_writes_are_uninstall_cleanup() {
+  local cache_root="${SB_RUNTIME_PLUGIN_CACHE_ROOT}"
+  local target_path
+  local saw_cache_target=false
+
+  [[ -n "$cache_root" ]] || return 1
+  [[ -f "$(sb_plugin_cache_registry_file)" ]] || return 1
+
+  for target_path in "$@"; do
+    [[ -n "$target_path" ]] || continue
+    case "$target_path" in
+      "$cache_root"|"$cache_root"/*) ;;
+      *) continue ;;
+    esac
+    saw_cache_target=true
+    if ! sb_plugin_cache_path_is_uninstalled "$target_path" "$cache_root"; then
+      return 1
+    fi
+  done
+
+  [[ "$saw_cache_target" == true ]]
+}

--- a/hooks/uat-gate.sh
+++ b/hooks/uat-gate.sh
@@ -41,16 +41,10 @@ fi
 UAT=".planning/UAT.md"
 SPEC=".planning/SPEC.md"
 
-# Only gate on release, milestone completion, or ship when SPEC defines acceptance criteria
-if ! printf '%s' "$skill" | grep -qE 'silver-release|silver-ship'; then
+# Gate milestone release only — phase-level ship (silver:ship) does not require UAT.md.
+# UAT is generated at milestone completion (silver:feature Step 17) before silver:release.
+if ! printf '%s' "$skill" | grep -qE 'silver-release'; then
   exit 0
-fi
-
-# Ship gate applies only when the project has a spec with acceptance criteria
-if printf '%s' "$skill" | grep -qE 'silver-ship'; then
-  if [[ ! -f "$SPEC" ]]; then
-    exit 0
-  fi
 fi
 
 # Check 1: UAT.md must exist (UATG-01)

--- a/hooks/workflow-chain-guard.sh
+++ b/hooks/workflow-chain-guard.sh
@@ -81,12 +81,17 @@ shopt -u nullglob
 [[ ${#active_workflows[@]} -gt 0 ]] || exit 0
 
 if [[ ${#active_workflows[@]} -gt 1 ]]; then
-  active_names=""
-  for wf in "${active_workflows[@]}"; do
-    active_names+="  • $(basename "$wf" .md)"$'\n'
-  done
-  emit_block "$(printf 'WORKFLOW DEPENDENCY GATE — multiple active composed workflows are present.\n\nActive workflows:\n%s\nResolve the active workflow selection before making implementation edits.' "$active_names")"
-  exit 0
+  scoped_id="${SB_WORKFLOW_ID:-}"
+  if [[ -n "$scoped_id" && -f "$wf_dir/$scoped_id.md" ]]; then
+    active_workflows=("$wf_dir/$scoped_id.md")
+  else
+    active_names=""
+    for wf in "${active_workflows[@]}"; do
+      active_names+="  • $(basename "$wf" .md)"$'\n'
+    done
+    emit_block "$(printf 'WORKFLOW DEPENDENCY GATE — multiple active composed workflows are present.\n\nActive workflows:\n%s\nSet SB_WORKFLOW_ID to the workflow you are executing, archive stale workflows with scripts/workflows.sh complete, or resolve the active set before making implementation edits.' "$active_names")"
+    exit 0
+  fi
 fi
 
 workflow_file="${active_workflows[0]}"
@@ -106,7 +111,7 @@ case "$composer_slug" in
     required_markers=(silver-blast-radius devops-quality-gates silver-context silver-plan)
     ;;
   silver-research)
-    required_markers=(silver-clarify)
+    required_markers=(silver-clarify silver-research)
     ;;
   silver-bugfix)
     # Bugfix is diagnosis-first: the documented pre-execution chain is

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-bullet",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Agentic Process Orchestrator for AI-native Software Engineering & DevOps. Provides SB-owned hook-enforced workflows for Claude Code, Codex, and Cursor with optional DevOps extension points.",
   "author": "Alo Labs <info@alolabs.dev>",
   "license": "MIT",

--- a/plugins/silver-bullet/.codex-plugin/plugin.json
+++ b/plugins/silver-bullet/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "silver-bullet",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Agentic Process Orchestrator for AI-native Software Engineering & DevOps. SB's Codex package contains Silver Bullet-owned skills, hooks, templates, and lifecycle workflows; optional extension plugins are installed from their official sources.",
   "author": {
     "name": "Alo Labs",

--- a/plugins/silver-bullet/.cursor-plugin/plugin.json
+++ b/plugins/silver-bullet/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "silver-bullet",
   "description": "Agentic Process Orchestrator for AI-native Software Engineering & DevOps. Provides SB-owned lifecycle workflows, optional extension-plugin boundaries, and layered technical compliance.",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "author": {
     "name": "Alo Labs",
     "email": "info@alolabs.dev"

--- a/plugins/silver-bullet/skill-source/silver-bugfix/SILVER_SOURCE
+++ b/plugins/silver-bullet/skill-source/silver-bugfix/SILVER_SOURCE
@@ -61,7 +61,7 @@ Display the composition proposal to the user:
 
 ```
 SILVER BULLET ► FLOW COMPOSED
-Flows: ORIENT → DEBUG → PLAN → EXECUTE → REVIEW → VERIFY → SECURE → SHIP
+Flows: ORIENT → DEBUG → PLAN → EXECUTE → REVIEW → VERIFY → SECURITY → SECURE → VALIDATE → QUALITY GATE → BRANCH-FINISH → COMPLETION-AUDIT → SHIP
 Skipped: BOOTSTRAP — .planning/ exists
 ```
 
@@ -224,7 +224,7 @@ Invoke `silver:verify` through the active runtime's SB-recognized skill invocati
 
 Invoke `security` through the active runtime's SB-recognized skill invocation channel. Non-skippable. Then invoke `silver:secure` for retroactive threat-mitigation verification — both `security` and `silver-secure` are part of `required_deploy`, so the completion-audit deploy gate blocks ship until both are recorded.
 
-> **Canonical post-execution order:** review (Step 5) → verify (Step 6) → security + secure (Step 7) → pre-ship quality gates (Step 7b) → ship (Step 8). This sequence matches `silver:feature`, `silver:ui`, and `silver:devops`.
+> **Canonical post-execution order:** review (Step 5) → verify (Step 6) → security + secure (Step 7) → quality gates (Step 7b) → validate (Step 7c) → branch-finish (Step 7d) → completion-audit (Step 7e) → ship (Step 8). This sequence matches `silver:feature`, `silver:ui`, and `silver:devops`.
 
 ## Step 7a: Tech Debt Review
 
@@ -249,7 +249,19 @@ Skill(skill="silver:add", args="<description of deferred item>")
 
 Invoke `silver:quality-gates` through the active runtime's SB-recognized skill invocation channel (affected quality dimensions for the changed code). Non-skippable.
 
-## Step 7c: Doc-Scheme Compliance (conditional)
+## Step 7c: Validate Phase
+
+Invoke `silver:validate` through the active runtime's SB-recognized skill invocation channel. Purpose: pre-ship validation gap filling and consistency check.
+
+## Step 7d: Finishing Branch
+
+On non-main branches, invoke `silver:branch-finish` through the active runtime's SB-recognized skill invocation channel before ship.
+
+## Step 7e: Completion Audit
+
+Invoke `silver:completion-audit` through the active runtime's SB-recognized skill invocation channel immediately before ship. Purpose: verify completion claims and evidence are substantive — required by `required_deploy` and must be recorded before `gh pr create`.
+
+## Step 7f: Doc-Scheme Compliance (conditional)
 
 **Only if `docs/doc-scheme.md` exists in the project:**
 

--- a/plugins/silver-bullet/skill-source/silver-devops/SILVER_SOURCE
+++ b/plugins/silver-bullet/skill-source/silver-devops/SILVER_SOURCE
@@ -37,6 +37,19 @@ Change: {$ARGUMENTS or "(not specified)"}
 Mode:   {interactive | autonomous — from §10e or session selection}
 ```
 
+### Activate devops-cycle enforcement profile
+
+At workflow start, set the project enforcement profile so hooks use `required_deploy_devops` and DevOps planning gates:
+
+```bash
+if [[ -f .silver-bullet.json ]] && command -v jq >/dev/null 2>&1; then
+  tmp="$(mktemp)"
+  jq '.project.active_workflow = "devops-cycle"' .silver-bullet.json > "$tmp" && mv "$tmp" .silver-bullet.json
+fi
+```
+
+This must run before the first planning skill so `completion-audit.sh` and `dev-cycle-check.sh` apply the DevOps skill lists.
+
 ## Composition Proposal
 
 Before beginning execution, read existing artifacts to determine context and propose which flows to include or skip.
@@ -262,6 +275,8 @@ If `docs/doc-scheme.md`/`docs/doc-scheme.json` are missing, recover via `/silver
 ## Step 11: Ship / Deploy
 
 Invoke `silver:ship` through the active runtime's SB-recognized skill invocation channel. Purpose: push branch, deploy, create PR.
+
+Before ship, invoke `silver:branch-finish` on feature branches and `silver:completion-audit` immediately before `silver:ship` (both are in `required_deploy_devops`).
 
 If this workflow performs or prepares an environment rollout, invoke
 `silver:deploy` before or inside ship according to the release plan. The deploy

--- a/plugins/silver-bullet/skill-source/silver-fast/SILVER_SOURCE
+++ b/plugins/silver-bullet/skill-source/silver-fast/SILVER_SOURCE
@@ -68,6 +68,8 @@ Make the small edit directly in the current session. Keep the change to the clas
 
 After the trivial edit and verification complete, run scope expansion check (Step 4).
 
+**Tier 1 discipline:** Do not misclassify logic changes as trivial to bypass workflow tracking. The `$HOME/.codex/.silver-bullet/trivial` marker only applies to genuine typo/config-only sessions; any src logic change requires Tier 2+ or `silver:feature`.
+
 If scope remained ≤3 files, display completion banner:
 
 ```

--- a/plugins/silver-bullet/skill-source/silver-feature/SILVER_SOURCE
+++ b/plugins/silver-bullet/skill-source/silver-feature/SILVER_SOURCE
@@ -38,7 +38,8 @@ After implementation, final delivery requires the post-execution chain. **Canoni
 5. `silver:validate`
 6. `silver:quality-gates` (pre-ship sweep)
 7. `silver:branch-finish` on feature branches
-8. `silver:ship`
+8. `silver:completion-audit` immediately before ship
+9. `silver:ship`
 
 If any required SB skill cannot be invoked, stop immediately and notify the user. Do not replace missing lifecycle skills with shell-only work, direct edits, or weaker fallback work.
 
@@ -73,7 +74,6 @@ Check the following artifacts and set skip/include flags:
 |----------|--------|--------|
 | `.planning/SPEC.md` exists | Specification already written | Skip FLOW 5 (SPECIFY) |
 | `.planning/PLAN.md` files exist for current phase | Planning already done | Skip FLOW 6 (PLAN) |
-| `.planning/VERIFICATION.md` exists, passing, and newer than last src change | Verification already done | Skip FLOW 12 (VERIFY) |
 | UI files detected in phase scope (*.tsx, *.css, *.html, design/) | UI work in scope | Include FLOW 7 (DESIGN CONTRACT) and FLOW 9 (UI QUALITY) |
 | `STATE.md` current phase and completion status | Phase position | Set loop start/end |
 
@@ -83,20 +83,6 @@ grep "^current_phase\|^current_plan" .planning/STATE.md 2>/dev/null
 
 # Check for existing SPEC.md
 [ -f ".planning/SPEC.md" ] && echo "SPEC exists — skip FLOW 5" || echo "No SPEC — include FLOW 5"
-
-# Check for stale verification (invalidate skip when src changed after VERIFICATION.md)
-if [ -f ".planning/VERIFICATION.md" ]; then
-  src_pattern=$(jq -r '.project.src_pattern // "/src/"' .silver-bullet.json 2>/dev/null || echo "/src/")
-  if find . -type f 2>/dev/null | grep -qE "$src_pattern"; then
-    ver_mtime=$(stat -f %m .planning/VERIFICATION.md 2>/dev/null || stat -c %Y .planning/VERIFICATION.md 2>/dev/null || echo 0)
-    newer_src=$(find . -type f 2>/dev/null | grep -E "$src_pattern" | while read -r f; do
-      stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0
-    done | awk -v v="$ver_mtime" '$1 > v { found=1; exit } END { exit !found }')
-    if [ "${newer_src:-1}" -eq 0 ]; then
-      echo "VERIFICATION.md is stale relative to src changes — include FLOW 12 (VERIFY)"
-    fi
-  fi
-fi
 
 # Check ROADMAP.md for remaining phases in milestone
 grep "^\-\s\[\s\]" .planning/ROADMAP.md 2>/dev/null | head -5
@@ -457,6 +443,10 @@ If `docs/doc-scheme.md`/`docs/doc-scheme.json` are missing, recover via `/silver
 ## Step 14: Finishing Branch
 
 Invoke `silver:branch-finish` through the active runtime's SB-recognized skill invocation channel. Purpose: merge / PR / cleanup decision, branch hygiene, and gate readiness.
+
+## Step 14b: Completion Audit
+
+Invoke `silver:completion-audit` through the active runtime's SB-recognized skill invocation channel immediately before ship. Purpose: verify completion claims and evidence — required by `required_deploy` and must be recorded before `gh pr create`.
 
 ## Step 15a: PR Branch (ask user)
 

--- a/plugins/silver-bullet/skill-source/silver-orchestrator/SILVER_SOURCE
+++ b/plugins/silver-bullet/skill-source/silver-orchestrator/SILVER_SOURCE
@@ -58,7 +58,7 @@ When spawning Task, include:
 
 ## Composer specs
 
-`silver-feature`, `silver-ui`, `silver-devops`, `silver-bugfix`, `silver-research`, `silver-fast` are **queue builders** — parent invokes them only to seed `orchestrator.json` / `workflows.sh`, then runs atoms via workers.
+`silver-feature`, `silver-ui`, `silver-devops`, `silver-bugfix`, `silver-research`, `silver-fast` are **queue builders** — parent invokes them only to seed `orchestrator.json` / `workflows.sh`, then runs atoms via workers. On tier-2 hosts, composer specs describe worker prompts; the parent never invokes flow-atom skills directly.
 
 ## Overrides
 

--- a/plugins/silver-bullet/skill-source/silver-release/SILVER_SOURCE
+++ b/plugins/silver-bullet/skill-source/silver-release/SILVER_SOURCE
@@ -332,6 +332,8 @@ session.
 Then invoke `silver:verify` for release-scope evidence review. Do not proceed to
 ship until both gates have fresh passing evidence.
 
+Invoke `silver:completion-audit` immediately before `silver:ship` to verify release-scope completion claims.
+
 ## Step 10: Ship - Branch, PR, CI, Deploy Readiness
 
 Invoke `silver:ship`. Purpose: complete phase-level shipping duties before the

--- a/plugins/silver-bullet/skill-source/silver-ui/SILVER_SOURCE
+++ b/plugins/silver-bullet/skill-source/silver-ui/SILVER_SOURCE
@@ -255,9 +255,13 @@ Invoke `silver:verify` through the active runtime's SB-recognized skill invocati
 
 **Fresh test execution (required before delivery):** Invoke `verify-tests` to run the project's test gate and record the freshness marker — it is part of `required_deploy`, so the completion-audit deploy gate blocks delivery until a fresh run is recorded. If coverage gaps remain after verification, route a test-gap task through `silver:execute`, then re-run `verify-tests`.
 
-## Step 11: Frontend Security
+## Step 11: Security Review
 
-Invoke `silver:secure` through the active runtime's SB-recognized skill invocation channel. Purpose: frontend security review — XSS, CSP, auth surface. Also invoke `security` as the mandatory security gate.
+Invoke `security` through the active runtime's SB-recognized skill invocation channel. Non-skippable gate.
+
+## Step 11b: Secure Phase
+
+Invoke `silver:secure` through the active runtime's SB-recognized skill invocation channel. Purpose: retroactive threat-mitigation verification and frontend security artifact update (XSS, CSP, auth surface).
 
 ## Step 12: Validate Phase
 
@@ -309,6 +313,10 @@ If `docs/doc-scheme.md`/`docs/doc-scheme.json` are missing, recover via `/silver
 ## Step 14: Finishing Branch
 
 Invoke `silver:branch-finish` through the active runtime's SB-recognized skill invocation channel.
+
+## Step 14b: Completion Audit
+
+Invoke `silver:completion-audit` through the active runtime's SB-recognized skill invocation channel immediately before ship.
 
 Ask user about PR branch:
 > Would you like a clean PR branch (strips .planning/ commits)?

--- a/plugins/silver-bullet/skill-source/silver-update/SILVER_SOURCE
+++ b/plugins/silver-bullet/skill-source/silver-update/SILVER_SOURCE
@@ -13,10 +13,13 @@ Check GitHub for the latest Silver Bullet release, display what changed since yo
 
 ### Step 1: Read installed version
 
-Read `$HOME/.codex/plugins/installed_plugins.json`. Try the `silver-bullet@alo-labs` key first; if absent, fall back to the `silver-bullet@silver-bullet` key (legacy installation):
+Read `$HOME/.codex/plugins/installed_plugins.json`. Try these keys in order:
 
-- `version` — currently installed version (e.g. `0.24.1`)
-- If neither key exists, treat installed version as `0.0.0`.
+- `silver-bullet@alo-labs` (Claude / Cursor marketplace)
+- `silver-bullet@alo-labs-codex` (Codex marketplace)
+- `silver-bullet@silver-bullet` (legacy installation)
+
+Use the first key that exists; read its `version` field (e.g. `0.24.1`). If none exist, treat installed version as `0.0.0`.
 
 Display:
 ```

--- a/plugins/silver-bullet/templates/silver-bullet.config.json.default
+++ b/plugins/silver-bullet/templates/silver-bullet.config.json.default
@@ -1,6 +1,6 @@
 {
-  "config_version": "0.42.0",
-  "version": "0.41.0",
+  "config_version": "0.43.0",
+  "version": "0.43.0",
   "sb_initiated": false,
   "sb_enforcement_tier": null,
   "orchestrator_mode": "parent",
@@ -59,7 +59,6 @@
       "silver-review-triage",
       "silver-branch-finish",
       "silver-completion-audit",
-      "tdd",
       "verify-tests"
     ],
     "required_release_devops": [

--- a/site/help/index.html
+++ b/site/help/index.html
@@ -6,7 +6,7 @@
 <link rel="icon" type="image/png" href="../favicon.png">
 <link rel="shortcut icon" href="../favicon.ico">
 <title>Silver Bullet Help Center</title>
-<meta name="description" content="Silver Bullet v0.42.0 Help Center — runtime parity enforcement, evidence schema gates, sb-bootstrap/sb-diagnostics, 49 orchestrator skills (77 total), and /silver workflows for Claude Code, Codex, and Cursor.">
+<meta name="description" content="Silver Bullet v0.43.0 Help Center — runtime parity enforcement, evidence schema gates, sb-bootstrap/sb-diagnostics, 49 orchestrator skills (77 total), and /silver workflows for Claude Code, Codex, and Cursor.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=IBM+Plex+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400;1,600;1,700&display=swap" rel="stylesheet">
@@ -113,7 +113,7 @@ svg.lucide{display:inline-block;vertical-align:middle;width:1em;height:1em;strok
   <div class="container">
     <div class="badge"><i data-lucide="book-open"></i> Help Center</div>
     <h1>How Can We Help You?</h1>
-    <p>Silver Bullet v0.42.0 documentation for Claude Code, Codex, and Cursor — install probes, hook-enforced workflows, evidence schema gates, and the full SB command reference.</p>
+    <p>Silver Bullet v0.43.0 documentation for Claude Code, Codex, and Cursor — install probes, hook-enforced workflows, evidence schema gates, and the full SB command reference.</p>
     <div class="search-wrap">
       <span class="search-icon"><i data-lucide="search"></i></span>
       <input type="text" placeholder="Search topics, commands, concepts…" id="search-input" autocomplete="off">
@@ -234,7 +234,7 @@ svg.lucide{display:inline-block;vertical-align:middle;width:1em;height:1em;strok
 
       <a href="workflows/" class="help-card" data-keywords="workflows orchestration silver brainstorm idea concept feature bugfix ui devops research release fast spec ingest validate routing">
         <div class="card-icon"><i data-lucide="git-branch-plus"></i></div>
-        <span class="card-badge" style="background:var(--slate-a12);color:var(--accent-light)">v0.42.0</span>
+        <span class="card-badge" style="background:var(--slate-a12);color:var(--accent-light)">v0.43.0</span>
         <h3>Orchestration Workflows</h3>
         <p>The named workflows that power Silver Bullet's dynamic routing — from idea clarification and specs to releases.</p>
         <ul class="card-topics">

--- a/site/help/reference/index.html
+++ b/site/help/reference/index.html
@@ -505,7 +505,7 @@ footer a:hover{color:var(--accent-light)}
       <p>Project-level configuration file in the repo root. Created by <code>/silver:init</code> and refreshed idempotently on re-run.</p>
 
       <div class="code-block">{
-  <span class="key">"version"</span>: <span class="str">"0.42.0"</span>,
+  <span class="key">"version"</span>: <span class="str">"0.43.0"</span>,
   <span class="key">"project"</span>: {
     <span class="key">"name"</span>: <span class="str">"my-app"</span>,
     <span class="key">"src_pattern"</span>: <span class="str">"/src/"</span>,

--- a/site/help/search.js
+++ b/site/help/search.js
@@ -29,7 +29,7 @@ var IDX = [
     "url": "/help/",
     "anchor": "",
     "title": "Silver Bullet Help Center",
-    "text": "Help Center landing page for Silver Bullet v0.42.0 concepts, getting started, three-host install, capability matrix, software workflow, DevOps workflow, command reference, named workflows, troubleshooting, and search."
+    "text": "Help Center landing page for Silver Bullet v0.43.0 concepts, getting started, three-host install, capability matrix, software workflow, DevOps workflow, command reference, named workflows, troubleshooting, and search."
   },
   {
     "page": "Core Concepts",
@@ -343,7 +343,7 @@ var IDX = [
     "page": "Reference",
     "url": "/help/reference/",
     "anchor": "runtime-parity",
-    "title": "Runtime parity scripts v0.42.0",
+    "title": "Runtime parity scripts v0.43.0",
     "text": "validate-evidence-findings.py evidence schema gate silver-add.sh fingerprint dedup prioritize stamp-interface-state.sh sb-bootstrap.sh sb-diagnostics.sh interface STATE.md delivery hook structural parity runtime enforcement"
   },
   {
@@ -351,7 +351,7 @@ var IDX = [
     "url": "/help/reference/",
     "anchor": "config",
     "title": "Configuration",
-    "text": "Current .silver-bullet.json includes version 0.42.0, project active_workflow, skills required_planning and required_deploy, all_tracked skills, devops_plugins, release gates, and state paths."
+    "text": "Current .silver-bullet.json includes version 0.43.0, project active_workflow, skills required_planning and required_deploy, all_tracked skills, devops_plugins, release gates, and state paths."
   },
   {
     "page": "Reference",

--- a/site/index.html
+++ b/site/index.html
@@ -959,7 +959,7 @@ img{max-width:100%;height:auto}
   <div class="container">
     <h1><span class="hero-h1-inner"><img src="silver-bullet.png" alt="" class="hero-bullet" aria-hidden="true"><span class="logo-wrapper"><span class="gradient">Silver Bullet</span><span class="alpha-badge">ALPHA</span></span></span></h1>
     <p class="hero-tagline-caps">FROM SPEC TO RELEASE &mdash; NOTHING SKIPPED</p>
-    <div class="version-badge"><span class="dot"></span> Agentic Process Orchestrator (APO) for AI-native Software Engineering &amp; DevOps &nbsp;&middot;&nbsp; v0.42.0</div>
+    <div class="version-badge"><span class="dot"></span> Agentic Process Orchestrator (APO) for AI-native Software Engineering &amp; DevOps &nbsp;&middot;&nbsp; v0.43.0</div>
 
     <div class="brooks-block">
       <img src="fred-brooks.jpg" alt="Fred Brooks" class="brooks-photo">
@@ -1543,7 +1543,7 @@ img{max-width:100%;height:auto}
     <div class="text-center">
       <div class="section-label">Live Enforcement</div>
       <h2 class="section-title">Runtime Parity You Can Enforce</h2>
-      <p class="section-desc centered">v0.42.0 is a launch-hardening release: a clarified two-tier enforcement model (planning floor at Stop, full delivery gate at ship), context-aware compliance reminders, a mandatory <code>security</code> + <code>verify-tests</code> delivery gate, and unified post-execute ordering across every composed flow.</p>
+      <p class="section-desc centered">v0.43.0 is a launch-hardening release: a clarified two-tier enforcement model (planning floor at Stop, full delivery gate at ship), context-aware compliance reminders, a mandatory <code>security</code> + <code>verify-tests</code> delivery gate, and unified post-execute ordering across every composed flow.</p>
     </div>
 
     <div class="grid grid-3 mt-6">
@@ -1634,7 +1634,7 @@ img{max-width:100%;height:auto}
           <tr>
             <th>Concern</th>
             <th>Typical quality-layer plugins</th>
-            <th>Silver Bullet (v0.42.0)</th>
+            <th>Silver Bullet (v0.43.0)</th>
           </tr>
         </thead>
         <tbody>

--- a/skills/silver-bugfix/SKILL.md
+++ b/skills/silver-bugfix/SKILL.md
@@ -60,7 +60,7 @@ Display the composition proposal to the user:
 
 ```
 SILVER BULLET ► FLOW COMPOSED
-Flows: ORIENT → DEBUG → PLAN → EXECUTE → REVIEW → VERIFY → SECURE → SHIP
+Flows: ORIENT → DEBUG → PLAN → EXECUTE → REVIEW → VERIFY → SECURITY → SECURE → VALIDATE → QUALITY GATE → BRANCH-FINISH → COMPLETION-AUDIT → SHIP
 Skipped: BOOTSTRAP — .planning/ exists
 ```
 
@@ -223,7 +223,7 @@ Invoke `silver:verify` through the active runtime's SB-recognized skill invocati
 
 Invoke `security` through the active runtime's SB-recognized skill invocation channel. Non-skippable. Then invoke `silver:secure` for retroactive threat-mitigation verification — both `security` and `silver-secure` are part of `required_deploy`, so the completion-audit deploy gate blocks ship until both are recorded.
 
-> **Canonical post-execution order:** review (Step 5) → verify (Step 6) → security + secure (Step 7) → pre-ship quality gates (Step 7b) → ship (Step 8). This sequence matches `silver:feature`, `silver:ui`, and `silver:devops`.
+> **Canonical post-execution order:** review (Step 5) → verify (Step 6) → security + secure (Step 7) → quality gates (Step 7b) → validate (Step 7c) → branch-finish (Step 7d) → completion-audit (Step 7e) → ship (Step 8). This sequence matches `silver:feature`, `silver:ui`, and `silver:devops`.
 
 ## Step 7a: Tech Debt Review
 
@@ -248,7 +248,19 @@ Skill(skill="silver:add", args="<description of deferred item>")
 
 Invoke `silver:quality-gates` through the active runtime's SB-recognized skill invocation channel (affected quality dimensions for the changed code). Non-skippable.
 
-## Step 7c: Doc-Scheme Compliance (conditional)
+## Step 7c: Validate Phase
+
+Invoke `silver:validate` through the active runtime's SB-recognized skill invocation channel. Purpose: pre-ship validation gap filling and consistency check.
+
+## Step 7d: Finishing Branch
+
+On non-main branches, invoke `silver:branch-finish` through the active runtime's SB-recognized skill invocation channel before ship.
+
+## Step 7e: Completion Audit
+
+Invoke `silver:completion-audit` through the active runtime's SB-recognized skill invocation channel immediately before ship. Purpose: verify completion claims and evidence are substantive — required by `required_deploy` and must be recorded before `gh pr create`.
+
+## Step 7f: Doc-Scheme Compliance (conditional)
 
 **Only if `docs/doc-scheme.md` exists in the project:**
 

--- a/skills/silver-devops/SKILL.md
+++ b/skills/silver-devops/SKILL.md
@@ -36,6 +36,19 @@ Change: {$ARGUMENTS or "(not specified)"}
 Mode:   {interactive | autonomous — from §10e or session selection}
 ```
 
+### Activate devops-cycle enforcement profile
+
+At workflow start, set the project enforcement profile so hooks use `required_deploy_devops` and DevOps planning gates:
+
+```bash
+if [[ -f .silver-bullet.json ]] && command -v jq >/dev/null 2>&1; then
+  tmp="$(mktemp)"
+  jq '.project.active_workflow = "devops-cycle"' .silver-bullet.json > "$tmp" && mv "$tmp" .silver-bullet.json
+fi
+```
+
+This must run before the first planning skill so `completion-audit.sh` and `dev-cycle-check.sh` apply the DevOps skill lists.
+
 ## Composition Proposal
 
 Before beginning execution, read existing artifacts to determine context and propose which flows to include or skip.
@@ -261,6 +274,8 @@ If `docs/doc-scheme.md`/`docs/doc-scheme.json` are missing, recover via `/silver
 ## Step 11: Ship / Deploy
 
 Invoke `silver:ship` through the active runtime's SB-recognized skill invocation channel. Purpose: push branch, deploy, create PR.
+
+Before ship, invoke `silver:branch-finish` on feature branches and `silver:completion-audit` immediately before `silver:ship` (both are in `required_deploy_devops`).
 
 If this workflow performs or prepares an environment rollout, invoke
 `silver:deploy` before or inside ship according to the release plan. The deploy

--- a/skills/silver-fast/SKILL.md
+++ b/skills/silver-fast/SKILL.md
@@ -67,6 +67,8 @@ Make the small edit directly in the current session. Keep the change to the clas
 
 After the trivial edit and verification complete, run scope expansion check (Step 4).
 
+**Tier 1 discipline:** Do not misclassify logic changes as trivial to bypass workflow tracking. The `${SB_RUNTIME_HOME_ROOT}/.silver-bullet/trivial` marker only applies to genuine typo/config-only sessions; any src logic change requires Tier 2+ or `silver:feature`.
+
 If scope remained ≤3 files, display completion banner:
 
 ```

--- a/skills/silver-feature/SKILL.md
+++ b/skills/silver-feature/SKILL.md
@@ -37,7 +37,8 @@ After implementation, final delivery requires the post-execution chain. **Canoni
 5. `silver:validate`
 6. `silver:quality-gates` (pre-ship sweep)
 7. `silver:branch-finish` on feature branches
-8. `silver:ship`
+8. `silver:completion-audit` immediately before ship
+9. `silver:ship`
 
 If any required SB skill cannot be invoked, stop immediately and notify the user. Do not replace missing lifecycle skills with shell-only work, direct edits, or weaker fallback work.
 
@@ -72,7 +73,6 @@ Check the following artifacts and set skip/include flags:
 |----------|--------|--------|
 | `.planning/SPEC.md` exists | Specification already written | Skip FLOW 5 (SPECIFY) |
 | `.planning/PLAN.md` files exist for current phase | Planning already done | Skip FLOW 6 (PLAN) |
-| `.planning/VERIFICATION.md` exists, passing, and newer than last src change | Verification already done | Skip FLOW 12 (VERIFY) |
 | UI files detected in phase scope (*.tsx, *.css, *.html, design/) | UI work in scope | Include FLOW 7 (DESIGN CONTRACT) and FLOW 9 (UI QUALITY) |
 | `STATE.md` current phase and completion status | Phase position | Set loop start/end |
 
@@ -82,20 +82,6 @@ grep "^current_phase\|^current_plan" .planning/STATE.md 2>/dev/null
 
 # Check for existing SPEC.md
 [ -f ".planning/SPEC.md" ] && echo "SPEC exists — skip FLOW 5" || echo "No SPEC — include FLOW 5"
-
-# Check for stale verification (invalidate skip when src changed after VERIFICATION.md)
-if [ -f ".planning/VERIFICATION.md" ]; then
-  src_pattern=$(jq -r '.project.src_pattern // "/src/"' .silver-bullet.json 2>/dev/null || echo "/src/")
-  if find . -type f 2>/dev/null | grep -qE "$src_pattern"; then
-    ver_mtime=$(stat -f %m .planning/VERIFICATION.md 2>/dev/null || stat -c %Y .planning/VERIFICATION.md 2>/dev/null || echo 0)
-    newer_src=$(find . -type f 2>/dev/null | grep -E "$src_pattern" | while read -r f; do
-      stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0
-    done | awk -v v="$ver_mtime" '$1 > v { found=1; exit } END { exit !found }')
-    if [ "${newer_src:-1}" -eq 0 ]; then
-      echo "VERIFICATION.md is stale relative to src changes — include FLOW 12 (VERIFY)"
-    fi
-  fi
-fi
 
 # Check ROADMAP.md for remaining phases in milestone
 grep "^\-\s\[\s\]" .planning/ROADMAP.md 2>/dev/null | head -5
@@ -456,6 +442,10 @@ If `docs/doc-scheme.md`/`docs/doc-scheme.json` are missing, recover via `/silver
 ## Step 14: Finishing Branch
 
 Invoke `silver:branch-finish` through the active runtime's SB-recognized skill invocation channel. Purpose: merge / PR / cleanup decision, branch hygiene, and gate readiness.
+
+## Step 14b: Completion Audit
+
+Invoke `silver:completion-audit` through the active runtime's SB-recognized skill invocation channel immediately before ship. Purpose: verify completion claims and evidence — required by `required_deploy` and must be recorded before `gh pr create`.
 
 ## Step 15a: PR Branch (ask user)
 

--- a/skills/silver-orchestrator/SKILL.md
+++ b/skills/silver-orchestrator/SKILL.md
@@ -57,7 +57,7 @@ When spawning Task, include:
 
 ## Composer specs
 
-`silver-feature`, `silver-ui`, `silver-devops`, `silver-bugfix`, `silver-research`, `silver-fast` are **queue builders** — parent invokes them only to seed `orchestrator.json` / `workflows.sh`, then runs atoms via workers.
+`silver-feature`, `silver-ui`, `silver-devops`, `silver-bugfix`, `silver-research`, `silver-fast` are **queue builders** — parent invokes them only to seed `orchestrator.json` / `workflows.sh`, then runs atoms via workers. On tier-2 hosts, composer specs describe worker prompts; the parent never invokes flow-atom skills directly.
 
 ## Overrides
 

--- a/skills/silver-release/SKILL.md
+++ b/skills/silver-release/SKILL.md
@@ -331,6 +331,8 @@ session.
 Then invoke `silver:verify` for release-scope evidence review. Do not proceed to
 ship until both gates have fresh passing evidence.
 
+Invoke `silver:completion-audit` immediately before `silver:ship` to verify release-scope completion claims.
+
 ## Step 10: Ship - Branch, PR, CI, Deploy Readiness
 
 Invoke `silver:ship`. Purpose: complete phase-level shipping duties before the

--- a/skills/silver-ui/SKILL.md
+++ b/skills/silver-ui/SKILL.md
@@ -254,9 +254,13 @@ Invoke `silver:verify` through the active runtime's SB-recognized skill invocati
 
 **Fresh test execution (required before delivery):** Invoke `verify-tests` to run the project's test gate and record the freshness marker — it is part of `required_deploy`, so the completion-audit deploy gate blocks delivery until a fresh run is recorded. If coverage gaps remain after verification, route a test-gap task through `silver:execute`, then re-run `verify-tests`.
 
-## Step 11: Frontend Security
+## Step 11: Security Review
 
-Invoke `silver:secure` through the active runtime's SB-recognized skill invocation channel. Purpose: frontend security review — XSS, CSP, auth surface. Also invoke `security` as the mandatory security gate.
+Invoke `security` through the active runtime's SB-recognized skill invocation channel. Non-skippable gate.
+
+## Step 11b: Secure Phase
+
+Invoke `silver:secure` through the active runtime's SB-recognized skill invocation channel. Purpose: retroactive threat-mitigation verification and frontend security artifact update (XSS, CSP, auth surface).
 
 ## Step 12: Validate Phase
 
@@ -308,6 +312,10 @@ If `docs/doc-scheme.md`/`docs/doc-scheme.json` are missing, recover via `/silver
 ## Step 14: Finishing Branch
 
 Invoke `silver:branch-finish` through the active runtime's SB-recognized skill invocation channel.
+
+## Step 14b: Completion Audit
+
+Invoke `silver:completion-audit` through the active runtime's SB-recognized skill invocation channel immediately before ship.
 
 Ask user about PR branch:
 > Would you like a clean PR branch (strips .planning/ commits)?

--- a/skills/silver-update/SKILL.md
+++ b/skills/silver-update/SKILL.md
@@ -12,10 +12,13 @@ Check GitHub for the latest Silver Bullet release, display what changed since yo
 
 ### Step 1: Read installed version
 
-Read `${SB_RUNTIME_HOME_ROOT}/plugins/installed_plugins.json`. Try the `silver-bullet@alo-labs` key first; if absent, fall back to the `silver-bullet@silver-bullet` key (legacy installation):
+Read `${SB_RUNTIME_HOME_ROOT}/plugins/installed_plugins.json`. Try these keys in order:
 
-- `version` — currently installed version (e.g. `0.24.1`)
-- If neither key exists, treat installed version as `0.0.0`.
+- `silver-bullet@alo-labs` (Claude / Cursor marketplace)
+- `silver-bullet@alo-labs-codex` (Codex marketplace)
+- `silver-bullet@silver-bullet` (legacy installation)
+
+Use the first key that exists; read its `version` field (e.g. `0.24.1`). If none exist, treat installed version as `0.0.0`.
 
 Display:
 ```

--- a/templates/silver-bullet.config.json.default
+++ b/templates/silver-bullet.config.json.default
@@ -1,6 +1,6 @@
 {
-  "config_version": "0.42.0",
-  "version": "0.41.0",
+  "config_version": "0.43.0",
+  "version": "0.43.0",
   "sb_initiated": false,
   "sb_enforcement_tier": null,
   "orchestrator_mode": "parent",
@@ -59,7 +59,6 @@
       "silver-review-triage",
       "silver-branch-finish",
       "silver-completion-audit",
-      "tdd",
       "verify-tests"
     ],
     "required_release_devops": [

--- a/tests/hooks/test-completion-audit.sh
+++ b/tests/hooks/test-completion-audit.sh
@@ -909,6 +909,49 @@ out=$(run_hook "PreToolUse" "git commit -m 'infra'")
 assert_blocks "devops: git commit blocked without silver-blast-radius/devops-quality-gates" "$out"
 teardown
 
+# Test 17b: devops-cycle uses required_deploy_devops list (not required_deploy)
+setup
+cat > "$TMPCFG" << EOF
+{
+  "config_version": "${CURRENT_CONFIG_VERSION}",
+  "sb_initiated": true,
+  "project": { "src_pattern": "/src/", "active_workflow": "devops-cycle" },
+  "skills": {
+    "required_planning": ["silver-quality-gates"],
+    "required_planning_devops": ["silver-blast-radius", "devops-quality-gates"],
+    "required_deploy": ["silver-quality-gates", "verify-tests"],
+    "required_deploy_devops": ["silver-blast-radius", "devops-quality-gates", "silver-review", "silver-review-request", "silver-review-triage", "silver-branch-finish", "silver-completion-audit", "verify-tests"],
+    "all_tracked": ["silver-quality-gates", "silver-blast-radius", "devops-quality-gates"]
+  },
+  "release": {
+    "require_plugin_runtime_matrix": false,
+    "require_pre_release_quality_gate": false,
+    "quality_gate_state_file": "${QUALITY_GATE_FILE}"
+  },
+  "state": { "state_file": "${TMPSTATE}", "trivial_file": "${SB_TEST_DIR}/trivial-test-${TEST_RUN_ID}" }
+}
+EOF
+echo "silver-quality-gates" > "$TMPSTATE"
+write_verify_tests_state
+mkdir -p "$TMPDIR_TEST/.planning/phases/001-test"
+cat > "$TMPDIR_TEST/.planning/phases/001-test/001-REVIEW.md" <<'EOF'
+# Review
+## Findings
+No issues found — review completed with evidence.
+EOF
+cat > "$TMPDIR_TEST/.planning/phases/001-test/001-VERIFICATION.md" <<'EOF'
+# Verification
+## Command output
+```bash
+$ npm test
+PASS
+```
+EOF
+out=$(run_hook "PreToolUse" "gh pr create --title 'infra'")
+assert_blocks "devops: PR blocked when only product deploy skills recorded (uses required_deploy_devops)" "$out"
+assert_contains "devops deploy list mentions silver-blast-radius" "$out" "silver-blast-radius"
+teardown
+
 # Test 18: Trivial file bypass
 echo "--- Group 6: Bypass mechanisms ---"
 setup

--- a/tests/hooks/test-dev-cycle-check.sh
+++ b/tests/hooks/test-dev-cycle-check.sh
@@ -720,6 +720,57 @@ out=$(run_hook_bash "PreToolUse" "cp /tmp/patch.js ${PLUGIN_CACHE_PATH}/some-plu
 assert_blocks "F-07: cp into plugin cache is still blocked" "$out"
 teardown
 
+# Test 22-uninstall: rm uninstalled plugin cache allowed when registry has no installPath (#222)
+setup
+UNINSTALL_CACHE="${PLUGIN_CACHE_PATH}/superpowers-marketplace"
+mkdir -p "$UNINSTALL_CACHE"
+REGISTRY="${SB_RUNTIME_HOME_ROOT}/plugins/installed_plugins.json"
+mkdir -p "$(dirname "$REGISTRY")"
+cat > "$REGISTRY" <<'EOF'
+{
+  "plugins": {
+    "silver-bullet@alo-labs": [
+      {
+        "version": "0.43.0",
+        "installPath": "REPLACE_SB_CACHE/alo-labs/silver-bullet/current"
+      }
+    ]
+  }
+}
+EOF
+python3 - "$REGISTRY" "${PLUGIN_CACHE_PATH}/alo-labs/silver-bullet/current" <<'PY'
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+data = json.loads(path.read_text())
+data["plugins"]["silver-bullet@alo-labs"][0]["installPath"] = sys.argv[2]
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+out=$(run_hook_bash "PreToolUse" "rm -rf ${UNINSTALL_CACHE}")
+assert_passes "F-07: rm uninstalled plugin cache dir allowed when registry omits it" "$out"
+teardown
+
+# Test 22-uninstall-block: rm still blocked when installPath references cache subtree
+setup
+INSTALLED_CACHE="${PLUGIN_CACHE_PATH}/episodic-memory-dev/episodic-memory/1.2.3"
+mkdir -p "$INSTALLED_CACHE"
+REGISTRY="${SB_RUNTIME_HOME_ROOT}/plugins/installed_plugins.json"
+mkdir -p "$(dirname "$REGISTRY")"
+cat > "$REGISTRY" <<EOF
+{
+  "plugins": {
+    "episodic-memory@episodic-memory-dev": [
+      {
+        "version": "1.2.3",
+        "installPath": "${INSTALLED_CACHE}"
+      }
+    ]
+  }
+}
+EOF
+out=$(run_hook_bash "PreToolUse" "rm -rf ${INSTALLED_CACHE}")
+assert_blocks "F-07: rm installed plugin cache dir still blocked when registry references it" "$out"
+teardown
+
 # Test 22a: script indirection through a symlink into plugin cache is blocked
 setup
 mkdir -p "$TMPDIR_TEST/.hook-probes"

--- a/tests/hooks/test-uat-gate.sh
+++ b/tests/hooks/test-uat-gate.sh
@@ -173,6 +173,19 @@ assert_blocks "silver:release blocked when spec version mismatches" "$out"
 assert_contains "block mentions version mismatch" "$out" "v1.0"
 teardown
 
+# Test 6b: silver:ship passes without UAT when SPEC exists (release-only UAT gate)
+setup
+cat > "$TMPDIR_TEST/.planning/SPEC.md" << 'EOF'
+spec-version: 1.0
+# Spec
+
+## Acceptance Criteria
+- AC-1: Works
+EOF
+out=$(run_hook "silver-ship")
+assert_passes "silver:ship not blocked when SPEC exists but UAT absent (phase ship)" "$out"
+teardown
+
 # Test 7: legacy gsd:complete-milestone (colon variant) also triggers the gate
 echo "--- Group 7: Legacy colon variant ---"
 setup

--- a/tests/hooks/test-workflow-chain-guard.sh
+++ b/tests/hooks/test-workflow-chain-guard.sh
@@ -128,7 +128,7 @@ out=$(run_hook_edit "$TMPDIR_TEST/src/app.js")
 assert_passes "silver:ui legacy GSD UI markers satisfy SB-owned aliases" "$out"
 teardown
 
-# Research workflow: clarify marker is required.
+# Research workflow: clarify + research markers are required.
 setup
 touch "$TMPDIR_TEST/src/app.js"
 start_workflow "/silver:research" "research gate test" "clarify,research,hand-off"
@@ -136,7 +136,21 @@ out=$(run_hook_edit "$TMPDIR_TEST/src/app.js")
 assert_blocks "silver:research blocks without clarify marker" "$out"
 write_state_markers silver-clarify
 out=$(run_hook_edit "$TMPDIR_TEST/src/app.js")
-assert_passes "silver:research passes after clarify marker exists" "$out"
+assert_blocks "silver:research blocks with only clarify marker (research missing)" "$out"
+write_state_markers silver-clarify silver-research
+out=$(run_hook_edit "$TMPDIR_TEST/src/app.js")
+assert_passes "silver:research passes after clarify + research markers exist" "$out"
+teardown
+
+# Multiple active workflows: SB_WORKFLOW_ID scopes the guard to one workflow file.
+setup
+touch "$TMPDIR_TEST/src/app.js"
+wf_a=$( cd "$TMPDIR_TEST" && bash "$WORKFLOWS_SCRIPT" start "/silver:feature" "wf-a" "plan,execute" )
+wf_b=$( cd "$TMPDIR_TEST" && bash "$WORKFLOWS_SCRIPT" start "/silver:bugfix" "wf-b" "debug,plan" )
+write_state_markers silver-quality-gates silver-context silver-plan
+input=$(jq -n --arg f "$TMPDIR_TEST/src/app.js" '{hook_event_name:"PreToolUse", tool_name:"Edit", tool_input:{file_path:$f, old_string:"old", new_string:"new"}}')
+out=$( cd "$TMPDIR_TEST" && export SB_WORKFLOW_ID="$wf_a" && printf '%s' "$input" | bash "$HOOK" 2>/dev/null )
+assert_passes "multiple active workflows pass when SB_WORKFLOW_ID scopes to prepared workflow" "$out"
 teardown
 
 # Bugfix workflow: diagnosis-first pre-execution chain is DEBUG → PLAN (B1).


### PR DESCRIPTION
## Summary
- Resolves all SB-REV-001–021 launch-readiness findings from adversarial review
- Closes #222 — allow `rm`/`rmdir` on uninstalled plugin cache paths
- Publishes **v0.43.0** (release cut from this branch)

Key changes:
- `completion-audit` uses `required_deploy_devops` for devops workflows
- UAT gate scoped to release only (phase `silver:ship` unblocked)
- Flow skills orchestrate `silver:completion-audit` before ship
- `silver:devops` activates `devops-cycle`; bugfix deploy chain completed
- `workflow-chain-guard` respects `SB_WORKFLOW_ID` with multiple active workflows

## Test plan
- [x] `test-completion-audit.sh` — 82 passed (+ devops deploy list)
- [x] `test-dev-cycle-check.sh` — 101 passed
- [x] `test-uat-gate.sh` — 17 passed
- [x] `test-workflow-chain-guard.sh` — 14 passed
- [x] Full `run-all-tests.sh` — 3388 passed, 0 failed


Made with [Cursor](https://cursor.com)