### PR TITLE
Extend Graphify+agentmemory stack optimizer to OpenCode, Goose, Hermes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,16 @@ CI enforces `silver-bullet.md` ↔ `templates/silver-bullet.md.base` parity (`te
 - `jq` is a required runtime dependency for the hooks.
 - Test fixtures should use temporary directories and leave the repo tree clean.
 - Small config/doc edits are still part of the repo contract if they affect enforcement.
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+When the user types `/graphify`, invoke the `skill` tool with `skill: "graphify"` before doing anything else.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- Dirty graphify-out/ files are expected after hooks or incremental updates; dirty graph files are not a reason to skip graphify. Only skip graphify if the task is about stale or incorrect graph output, or the user explicitly says not to use it.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/docs/GRAPHIFY.md
+++ b/docs/GRAPHIFY.md
@@ -70,6 +70,9 @@ Run from the project root after the CLI is on PATH. SB stores these in
 | Claude Code | `graphify install --project` | `graphify claude install --project` | `.claude/settings.json` |
 | Codex | `graphify install --project --platform codex` | `graphify codex install --project` | `.codex/hooks.json` |
 | Cursor | *(none)* | `graphify cursor install` | `.cursor/rules/graphify.mdc` ([issue #137](https://github.com/safishamsi/graphify/issues/137#issuecomment-4215764533)) |
+| OpenCode | `graphify install --project --platform opencode` | *(hooks in `.opencode/plugins/graphify.js`)* | `.opencode/opencode.json` |
+| Goose (Pi) | `graphify install --project --platform pi` | *(skill only)* | `.pi/agent/skills/graphify/SKILL.md` |
+| Hermes | `graphify install --project --platform hermes` | *(AGENTS.md rules — no PreToolUse)* | `AGENTS.md` graphify section |
 
 Codex also needs `multi_agent = true` under `[features]` in `~/.codex/config.toml` for parallel extraction (upstream note).
 

--- a/docs/STACK-OPTIMIZATION.md
+++ b/docs/STACK-OPTIMIZATION.md
@@ -1,8 +1,30 @@
 # Stack Optimization (Graphify + agentmemory)
 
-Silver Bullet applies a **post-install optimization layer** when users opt into Graphify and/or agentmemory. Default profile: **`synergy_max`**.
+Default profile: **`synergy_max`**.
 
-## When it runs
+## Global setup (SB-independent — primary for Claude, Codex, OpenCode, Goose, Hermes)
+
+Machine-level wiring does **not** require Silver Bullet, `/silver:init`, `.silver-bullet.json`, or SB hooks:
+
+```bash
+bash scripts/graphify-am-global-setup.sh --host claude --apply
+bash scripts/graphify-am-global-setup.sh --host codex --verify
+bash scripts/graphify-am-global-setup.sh --host all --verify    # detected hosts only
+bash scripts/graphify-am-global-setup.sh --host claude --apply --repo /path/to/project
+```
+
+| Deliverable | Path |
+|-------------|------|
+| Global setup script | `scripts/graphify-am-global-setup.sh` |
+| Implementation lib | `hooks/lib/graphify-am-global.sh` |
+| Platform matrix | `docs/graphify-am/PLATFORM-MATRIX.md` |
+| Per-agent verification | `docs/graphify-am/verification/<host>-verify-graphify-am.md` |
+
+Without `--repo`, `AGENTMEMORY_EXPORT_ROOT` defaults to `~/.agentmemory/default-export`. Pass `--repo` for per-project export, bridge launchd, and optional `graphify update`.
+
+Silver Bullet **may delegate** to global setup during `/silver:init` Step 3f, then run project-level `sb-optimize-stack.sh` when the user has opted in.
+
+## When SB optimization runs
 
 | Trigger | Command |
 |---------|---------|
@@ -50,11 +72,18 @@ Warnings (non-blocking): missing git hooks, bridge, gitleaks, launchd.
 
 ## Platform matrix
 
-| Host | Graphify | agentmemory |
-|------|----------|-------------|
-| Cursor | `graphify cursor install` → `.cursor/rules/graphify.mdc` | MCP in `~/.cursor/mcp.json` |
-| Claude | `graphify install --project` + `graphify claude install --project` | `agentmemory connect claude-code` |
-| Codex | `graphify install --project --platform codex` + `graphify codex install --project` | `agentmemory connect codex --with-hooks` |
+| Host | Graphify | agentmemory | Artifact paths |
+|------|----------|-------------|----------------|
+| Cursor | `graphify cursor install` → `.cursor/rules/graphify.mdc` | MCP in `~/.cursor/mcp.json` | Full `connect` support |
+| Claude | `graphify install --project` + `graphify claude install --project` | `agentmemory connect claude-code` | `~/.claude.json` |
+| Codex | `graphify install --project --platform codex` + `graphify codex install --project` | `agentmemory connect codex --with-hooks` | `~/.codex/config.toml` |
+| OpenCode | `graphify install --project --platform opencode` | **Manual MCP** in `~/.config/opencode/opencode.json` | No `connect opencode` subcommand |
+| Goose (Pi) | `graphify install --project --platform pi` | **Manual** `agentmemory connect pi` (TS extension) | `~/.config/goose/config.yaml`, `.pi/agent/` |
+| Hermes | `graphify install --project --platform hermes` | **Manual** `agentmemory connect hermes` (YAML merge) | `~/.hermes/config.yaml`, `AGENTS.md` rules |
+
+Apply per host: `SILVER_BULLET_RUNTIME=<host> bash scripts/sb-optimize-stack.sh --apply --host <host>`
+
+Verification addenda: `docs/graphify-am/verification/<host>-verify-graphify-am.md`
 
 ## Verification addendum mapping
 

--- a/docs/graphify-am/PLATFORM-MATRIX.md
+++ b/docs/graphify-am/PLATFORM-MATRIX.md
@@ -1,0 +1,58 @@
+# Graphify + agentmemory — Global Platform Matrix
+
+**Profile:** `synergy_max` (see `docs/research/graphify-agentmemory-optimization.md`)  
+**Setup script:** `bash scripts/graphify-am-global-setup.sh --host <host> --apply`  
+**SB-independent:** no `/silver:init`, no `.silver-bullet.json`, no SB hooks required.
+
+## Global install commands (no `--project`)
+
+| Host | Graphify pre-index | Graphify always-on | agentmemory wiring | Global artifact paths |
+|------|-------------------|--------------------|--------------------|------------------------|
+| **Claude Code** | `graphify install` | `graphify claude install` | `agentmemory connect claude-code` | `~/.claude/skills/graphify/`, `~/.claude.json` |
+| **Codex** | `graphify install --platform codex` | `graphify codex install` | `codex plugin …` + `agentmemory connect codex --with-hooks` | `~/.codex/skills/graphify/`, `~/.codex/config.toml` |
+| **OpenCode** | `graphify install --platform opencode` | `graphify opencode install` | **Manual MCP** merge in `~/.config/opencode/opencode.json` | `~/.config/opencode/opencode.json` |
+| **Goose (Pi)** | `graphify install --platform pi` | `graphify pi install` | `agentmemory connect pi` | `~/.pi/agent/skills/graphify/`, `~/.config/goose/config.yaml` |
+| **Hermes** | `graphify install --platform hermes` | `graphify hermes install` | `agentmemory connect hermes` | `~/.hermes/skills/graphify/`, `~/.hermes/config.yaml` |
+
+## Shared machine-level steps (all hosts)
+
+| Step | Command / path | Notes |
+|------|----------------|-------|
+| Graphify CLI | `uv tool install graphifyy` or `pipx install graphifyy` | Python 3.10+ |
+| agentmemory CLI | `npm install -g @agentmemory/agentmemory` | Node 20+ |
+| synergy_max `.env` | `~/.agentmemory/.env` | Script merges managed block; chmod 600 |
+| Server persistence | macOS: `~/Library/LaunchAgents/com.agentmemory.server.plist` | Linux: systemd user unit (manual) |
+| Git hooks | `graphify hook install` | Global git template — new repos inherit |
+| Export root (default) | `~/.agentmemory/default-export` | Override with `--repo /path/to/project` |
+| Bridge (optional) | `com.agentmemory.bridge` launchd | Only when `--repo` passed and `~/.agentmemory/bridge.py` exists |
+
+## Synergy loop (per project)
+
+1. Capture via agentmemory MCP in the agent UI  
+2. Export → `.agentmemory/memory/` (absolute `AGENTMEMORY_EXPORT_ROOT`)  
+3. Bridge auto-commits (optional)  
+4. `graphify update . --no-cluster`  
+5. `graphify query "<topic>"` must return `.agentmemory` nodes  
+
+**Anti-pattern:** reading raw `.agentmemory/` dumps when Graphify is enabled — save via agentmemory, retrieve via Graphify.
+
+## Verification prompts
+
+| Host | Doc |
+|------|-----|
+| Claude | `docs/graphify-am/verification/claude-verify-graphify-am.md` |
+| Codex | `docs/graphify-am/verification/codex-verify-graphify-am.md` |
+| OpenCode | `docs/graphify-am/verification/opencode-verify-graphify-am.md` |
+| Goose | `docs/graphify-am/verification/goose-verify-graphify-am.md` |
+| Hermes | `docs/graphify-am/verification/hermes-verify-graphify-am.md` |
+
+## Silver Bullet integration (optional)
+
+When SB is active in a repo, `/silver:init` Step 3f may **delegate** to global setup, then apply project-level index/gitignore:
+
+```bash
+bash scripts/graphify-am-global-setup.sh --host claude --apply --repo .
+bash scripts/sb-optimize-stack.sh --apply --host claude
+```
+
+SB project optimization still requires `recommended_tools.*.enabled_by_user: true`. Global setup does not.

--- a/docs/graphify-am/verification/claude-verify-graphify-am.md
+++ b/docs/graphify-am/verification/claude-verify-graphify-am.md
@@ -1,0 +1,120 @@
+# Self-Verification: Graphify + agentmemory in Claude Code (Global)
+
+Machine-level audit for **Claude Code** — no Silver Bullet prerequisite. Produces a pass/fail report per check.
+
+**Setup script:** `bash scripts/graphify-am-global-setup.sh --host claude --apply`
+
+---
+
+## Phase 1 — Pre-flight (read-only)
+
+### 1.1 Graphify CLI
+
+```bash
+which graphify && graphify --version 2>/dev/null | head -1
+```
+
+**Pass:** path under `/opt/homebrew`, `/usr/local`, or `~/.local` and version present.
+
+**Fail:** install `uv tool install graphifyy` or `pipx install graphifyy`.
+
+### 1.2 agentmemory CLI
+
+```bash
+which agentmemory && agentmemory --version 2>/dev/null | head -1
+```
+
+**Pass:** binary on PATH.
+
+**Fail:** `npm install -g @agentmemory/agentmemory`
+
+---
+
+## Phase 2 — Global config artifacts
+
+### 2.1 Graphify skill (global)
+
+```bash
+test -f ~/.claude/skills/graphify/SKILL.md && grep -q graphify ~/.claude/skills/graphify/SKILL.md && echo OK
+```
+
+**Pass:** skill file exists with graphify content.
+
+**Fail:** `graphify install` (no `--project`).
+
+### 2.2 Graphify always-on hooks
+
+```bash
+grep -r graphify ~/.claude/CLAUDE.md ~/.claude/settings.json 2>/dev/null | head -3
+```
+
+**Pass:** graphify PreToolUse or rules reference present.
+
+**Fail:** `graphify claude install` (global).
+
+### 2.3 agentmemory MCP
+
+```bash
+jq '.mcpServers | keys[]' ~/.claude.json 2>/dev/null | grep -i agentmemory
+```
+
+**Pass:** `agentmemory` key in `~/.claude.json` mcpServers.
+
+**Fail:** `agentmemory connect claude-code`
+
+### 2.4 synergy_max `.env`
+
+```bash
+grep AGENTMEMORY_INJECT_CONTEXT=true ~/.agentmemory/.env
+grep AGENTMEMORY_EXPORT_ROOT ~/.agentmemory/.env
+```
+
+**Pass:** both lines present; export root is absolute.
+
+**Fail:** `bash scripts/graphify-am-global-setup.sh --host claude --apply`
+
+---
+
+## Phase 3 — Server and persistence
+
+### 3.1 Health
+
+```bash
+curl -sf http://localhost:3111/agentmemory/health && echo OK
+```
+
+### 3.2 launchd (macOS)
+
+```bash
+launchctl list 2>/dev/null | grep com.agentmemory.server
+```
+
+**Warn if missing:** `nohup agentmemory > ~/.agentmemory/server.log 2>&1 &` or re-run global setup.
+
+### 3.3 Git hooks (global template)
+
+```bash
+graphify hook status
+```
+
+**Pass:** post-commit and post-checkout installed.
+
+---
+
+## Phase 4 — Manual synergy test (in Claude Code UI)
+
+1. Open a git repo with code. Optionally pass `--repo` to global setup for export root.
+2. Ask Claude to **save a decision** via agentmemory MCP (e.g. "Remember: we use jq for all JSON in this repo").
+3. Trigger export: `curl -sf -X POST http://localhost:3111/agentmemory/obsidian/export -H 'Content-Type: application/json' -d '{"vaultDir":"'"$(grep AGENTMEMORY_EXPORT_ROOT ~/.agentmemory/.env | cut -d= -f2)"'/memory"}'`
+4. From repo root: `graphify update . --no-cluster`
+5. `graphify query "jq JSON decision" --budget 2000` — result should include `.agentmemory` nodes.
+
+**Pass:** query returns memory-related nodes.
+
+---
+
+## Appendix — If Silver Bullet is active in a repo
+
+- SB may run `bash scripts/sb-optimize-stack.sh --apply --host claude` for project gitignore, index, and consent timestamps.
+- Hooks (`graphify-gate`, `agentmemory-gate`) apply only when `recommended_tools.*.enabled_by_user: true`.
+- Global setup remains authoritative for `~/.agentmemory/.env` and `~/.claude.json` MCP.

--- a/docs/graphify-am/verification/codex-verify-graphify-am.md
+++ b/docs/graphify-am/verification/codex-verify-graphify-am.md
@@ -1,0 +1,82 @@
+# Self-Verification: Graphify + agentmemory in Codex (Global)
+
+Machine-level audit for **OpenAI Codex CLI** — no Silver Bullet prerequisite.
+
+**Setup script:** `bash scripts/graphify-am-global-setup.sh --host codex --apply`
+
+---
+
+## Phase 1 — Pre-flight
+
+```bash
+which graphify && which agentmemory && which codex
+```
+
+Install gaps: `uv tool install graphifyy`, `npm install -g @agentmemory/agentmemory`, Codex per upstream docs.
+
+---
+
+## Phase 2 — Global config artifacts
+
+### 2.1 Graphify skill + always-on
+
+```bash
+test -f ~/.codex/skills/graphify/SKILL.md 2>/dev/null || ls ~/.codex/skills/graphify/ 2>/dev/null
+grep -i graphify ~/.codex/AGENTS.md 2>/dev/null | head -2
+```
+
+**Apply:** `graphify install --platform codex` then `graphify codex install` (no `--project`).
+
+### 2.2 agentmemory plugin + MCP
+
+```bash
+grep -i agentmemory ~/.codex/config.toml
+codex plugin list 2>/dev/null | grep -i agentmemory
+```
+
+**Apply:**
+
+```bash
+codex plugin marketplace add rohitg00/agentmemory
+codex plugin add agentmemory@agentmemory
+agentmemory connect codex --with-hooks
+```
+
+### 2.3 `multi_agent` feature (parallel extraction)
+
+```bash
+grep -E '^multi_agent\s*=\s*true' ~/.codex/config.toml
+```
+
+**Fail:** add under `[features]`: `multi_agent = true`
+
+### 2.4 synergy_max `.env`
+
+```bash
+grep AGENTMEMORY_INJECT_CONTEXT=true ~/.agentmemory/.env
+```
+
+---
+
+## Phase 3 — Server and hooks
+
+```bash
+curl -sf http://localhost:3111/agentmemory/health
+graphify hook status
+launchctl list 2>/dev/null | grep com.agentmemory.server || true
+```
+
+---
+
+## Phase 4 — Manual synergy test (Codex UI)
+
+1. In a repo, use agentmemory tools to capture a short note.
+2. Export obsidian vault to `AGENTMEMORY_EXPORT_ROOT/memory`.
+3. `graphify update . --no-cluster`
+4. `graphify query "<note topic>" --budget 2000` — expect `.agentmemory` in results.
+
+---
+
+## Appendix — If Silver Bullet is active
+
+`SILVER_BULLET_RUNTIME=codex bash scripts/sb-optimize-stack.sh --apply --host codex` adds project-level optimization when opted in. Global `~/.codex/config.toml` wiring is unchanged.

--- a/docs/graphify-am/verification/goose-verify-graphify-am.md
+++ b/docs/graphify-am/verification/goose-verify-graphify-am.md
@@ -1,0 +1,66 @@
+# Self-Verification: Graphify + agentmemory in Goose (Pi runtime, Global)
+
+Machine-level audit for **Block Goose** (Pi coding-agent runtime) — no Silver Bullet prerequisite.
+
+Goose uses the **Pi** upstream platform for Graphify and `agentmemory connect pi`.
+
+**Setup script:** `bash scripts/graphify-am-global-setup.sh --host goose --apply`
+
+---
+
+## Phase 1 — Pre-flight
+
+```bash
+which graphify && which agentmemory
+test -f ~/.config/goose/config.yaml && echo goose-config-ok
+```
+
+---
+
+## Phase 2 — Global config artifacts
+
+### 2.1 Graphify skill (Pi path)
+
+```bash
+test -f ~/.pi/agent/skills/graphify/SKILL.md && grep -q graphify ~/.pi/agent/skills/graphify/SKILL.md && echo OK
+```
+
+**Apply:** `graphify install --platform pi` && `graphify pi install`
+
+### 2.2 agentmemory (Pi extension)
+
+```bash
+grep -i agentmemory ~/.config/goose/config.yaml 2>/dev/null
+agentmemory status 2>/dev/null | grep -i pi
+```
+
+**Apply:** `agentmemory connect pi` (see agentmemory `integrations/pi.md`)
+
+### 2.3 synergy_max `.env`
+
+```bash
+grep AGENTMEMORY_INJECT_CONTEXT=true ~/.agentmemory/.env
+```
+
+---
+
+## Phase 3 — Server and hooks
+
+```bash
+curl -sf http://localhost:3111/agentmemory/health
+graphify hook status
+```
+
+---
+
+## Phase 4 — Manual synergy test (Goose UI)
+
+1. In Goose, invoke graphify skill or run `graphify query` from a project terminal.
+2. Capture a note via agentmemory/Pi tools if exposed.
+3. Export, re-index, query — confirm memory nodes appear in graph.
+
+---
+
+## Appendix — If Silver Bullet is active
+
+SB maps host id `goose` → graphify platform `pi`. Project-level `.pi/agent/` artifacts may also exist; global `~/.pi/agent/skills/graphify/` takes precedence for new sessions.

--- a/docs/graphify-am/verification/hermes-verify-graphify-am.md
+++ b/docs/graphify-am/verification/hermes-verify-graphify-am.md
@@ -1,0 +1,66 @@
+# Self-Verification: Graphify + agentmemory in Hermes (Global)
+
+Machine-level audit for **Hermes** agent — no Silver Bullet prerequisite.
+
+**Setup script:** `bash scripts/graphify-am-global-setup.sh --host hermes --apply`
+
+---
+
+## Phase 1 — Pre-flight
+
+```bash
+which graphify && which agentmemory
+test -d ~/.hermes && echo hermes-home-ok
+```
+
+---
+
+## Phase 2 — Global config artifacts
+
+### 2.1 Graphify skill
+
+```bash
+test -f ~/.hermes/skills/graphify/SKILL.md && echo graphify-skill-ok
+```
+
+**Apply:** `graphify install --platform hermes` && `graphify hermes install`
+
+### 2.2 agentmemory wiring
+
+```bash
+grep -i agentmemory ~/.hermes/config.yaml 2>/dev/null
+agentmemory status 2>/dev/null | grep -i hermes
+```
+
+**Apply:** `agentmemory connect hermes`
+
+### 2.3 synergy_max `.env`
+
+```bash
+grep AGENTMEMORY_INJECT_CONTEXT=true ~/.agentmemory/.env
+grep AGENTMEMORY_EXPORT_ROOT ~/.agentmemory/.env
+```
+
+---
+
+## Phase 3 — Server and hooks
+
+```bash
+curl -sf http://localhost:3111/agentmemory/health
+graphify hook status
+launchctl list 2>/dev/null | grep com.agentmemory.server || true
+```
+
+---
+
+## Phase 4 — Manual synergy test (Hermes UI)
+
+1. Confirm graphify skill loads in Hermes sessions.
+2. Save a decision via agentmemory.
+3. In a git repo: export → `graphify update . --no-cluster` → `graphify query`.
+
+---
+
+## Appendix — If Silver Bullet is active
+
+Hermes is in SB `multi_agent.identity_tags`. Global `~/.hermes/` config is independent of `.silver-bullet.json`.

--- a/docs/graphify-am/verification/opencode-verify-graphify-am.md
+++ b/docs/graphify-am/verification/opencode-verify-graphify-am.md
@@ -1,0 +1,76 @@
+# Self-Verification: Graphify + agentmemory in OpenCode (Global)
+
+Machine-level audit for **OpenCode** — no Silver Bullet prerequisite.
+
+**Setup script:** `bash scripts/graphify-am-global-setup.sh --host opencode --apply`
+
+---
+
+## Phase 1 — Pre-flight
+
+```bash
+which graphify && which agentmemory && which opencode 2>/dev/null || which oc 2>/dev/null
+```
+
+---
+
+## Phase 2 — Global config artifacts
+
+### 2.1 OpenCode config exists
+
+```bash
+test -f ~/.config/opencode/opencode.json && jq . ~/.config/opencode/opencode.json >/dev/null && echo OK
+```
+
+### 2.2 Graphify plugin + skill
+
+```bash
+jq '.plugin // .plugins // empty' ~/.config/opencode/opencode.json 2>/dev/null
+ls ~/.config/opencode/skills/graphify/SKILL.md 2>/dev/null || ls ~/.opencode/skills/graphify/SKILL.md 2>/dev/null
+```
+
+**Apply:** `graphify install --platform opencode` && `graphify opencode install`
+
+### 2.3 agentmemory MCP (manual — no `connect opencode`)
+
+```bash
+jq '.mcp.agentmemory // .mcpServers.agentmemory // empty' ~/.config/opencode/opencode.json
+```
+
+**Pass:** stdio MCP block with `npx -y @agentmemory/mcp` and `AGENTMEMORY_URL`.
+
+**Fail:** re-run global setup or merge manually:
+
+```bash
+bash scripts/graphify-am-global-setup.sh --host opencode --apply
+```
+
+### 2.4 synergy_max `.env`
+
+```bash
+grep AGENTMEMORY_EXPORT_ROOT ~/.agentmemory/.env
+```
+
+---
+
+## Phase 3 — Server
+
+```bash
+curl -sf http://localhost:3111/agentmemory/health
+graphify hook status
+```
+
+---
+
+## Phase 4 — Manual synergy test (OpenCode UI)
+
+1. Confirm agentmemory MCP tools appear in OpenCode tool list.
+2. Save a constraint via MCP.
+3. Export + `graphify update . --no-cluster` in your working repo.
+4. `graphify query` for the saved topic.
+
+---
+
+## Appendix — If Silver Bullet is active
+
+OpenCode is listed in `multi_agent.identity_tags`. SB project hooks are optional; global `~/.config/opencode/opencode.json` is authoritative for MCP.

--- a/docs/research/graphify-agentmemory-optimization.md
+++ b/docs/research/graphify-agentmemory-optimization.md
@@ -47,12 +47,12 @@ Multi-agent teams get the best retrieval/capture loop when **agentmemory exports
 
 ## Platform Matrix
 
-| Surface | Cursor | Claude Code | Codex |
-|---------|--------|-------------|-------|
-| Graphify install | `graphify cursor install` | `graphify install --project` + `graphify claude install --project` | `graphify install --project --platform codex` + `graphify codex install --project` |
-| agentmemory MCP | `~/.cursor/mcp.json` | `agentmemory connect claude-code` | `agentmemory connect codex --with-hooks` |
-| Hook strength | SB graphify-gate + rules | Claude settings hooks + skill | Codex hooks.json |
-| Optimization script | `bash scripts/sb-optimize-stack.sh --apply` | same | same |
+| Surface | Cursor | Claude Code | Codex | OpenCode | Goose (Pi) | Hermes |
+|---------|--------|-------------|-------|----------|------------|--------|
+| Graphify install | `graphify cursor install` | `graphify install --project` + `graphify claude install --project` | `graphify install --project --platform codex` + `graphify codex install --project` | `graphify install --project --platform opencode` | `graphify install --project --platform pi` | `graphify install --project --platform hermes` |
+| agentmemory MCP | `~/.cursor/mcp.json` | `agentmemory connect claude-code` | `agentmemory connect codex --with-hooks` | Manual MCP in `opencode.json` | Manual `connect pi` (TS extension) | Manual `connect hermes` (YAML) |
+| Hook strength | SB graphify-gate + rules | Claude settings hooks + skill | Codex hooks.json | `.opencode/plugins/graphify.js` | Pi extension (manual) | AGENTS.md rules only |
+| Optimization script | `bash scripts/sb-optimize-stack.sh --apply --host <host>` | same | same | same | same | same |
 
 ## gitignore Fix (mandatory)
 

--- a/hooks/lib/agentmemory-gate.sh
+++ b/hooks/lib/agentmemory-gate.sh
@@ -86,6 +86,9 @@ sb_agentmemory_platform_artifact_path() {
   case "$host" in
     cursor) printf '%s/.cursor/mcp.json' "${HOME}" ;;
     codex) printf '%s/.codex/config.toml' "${HOME}" ;;
+    opencode) printf '%s/.config/opencode/opencode.json' "${HOME}" ;;
+    goose) printf '%s/.config/goose/config.yaml' "${HOME}" ;;
+    hermes) printf '%s/.hermes/config.yaml' "${HOME}" ;;
     *) printf '%s/.claude.json' "${HOME}" ;;
   esac
 }

--- a/hooks/lib/graphify-am-global.sh
+++ b/hooks/lib/graphify-am-global.sh
@@ -185,7 +185,9 @@ ga_opencode_merge_agentmemory_mcp() {
     return 0
   fi
   if [[ ! -f "$cfg" ]]; then
-    printf '{"$schema":"https://opencode.ai/config.json","mcp":{"agentmemory":{"type":"stdio","command":"npx","args":["-y","@agentmemory/mcp"],"env":{"AGENTMEMORY_URL":"http://localhost:3111"}}}}\n' >"$cfg"
+    cat >"$cfg" <<'JSON'
+{"$schema":"https://opencode.ai/config.json","mcp":{"agentmemory":{"type":"stdio","command":"npx","args":["-y","@agentmemory/mcp"],"env":{"AGENTMEMORY_URL":"http://localhost:3111"}}}}
+JSON
     return 0
   fi
   command -v jq >/dev/null 2>&1 || return 1

--- a/hooks/lib/graphify-am-global.sh
+++ b/hooks/lib/graphify-am-global.sh
@@ -1,0 +1,470 @@
+# shellcheck shell=bash
+# Graphify + agentmemory global setup — SB-independent synergy_max apply/verify.
+# Sourced by: scripts/graphify-am-global-setup.sh
+
+GA_SUPPORTED_HOSTS="claude codex opencode goose hermes"
+GA_DEFAULT_PROFILE="synergy_max"
+GA_DEFAULT_EXPORT_FALLBACK="${HOME}/.agentmemory/default-export"
+
+ga_skip_host_hooks() {
+  [[ "${CI:-}" == "true" ]] || [[ "${CI:-}" == "1" ]] \
+    || [[ "${GA_SKIP_HOST_HOOKS:-0}" == "1" ]]
+}
+
+ga_dry_run() {
+  [[ "${GA_GLOBAL_DRY_RUN:-0}" == "1" ]]
+}
+
+ga_agentmemory_home() {
+  printf '%s' "${GA_AGENTMEMORY_HOME:-${HOME}/.agentmemory}"
+}
+
+ga_validate_host() {
+  local host="${1:-}"
+  case " ${GA_SUPPORTED_HOSTS} " in
+    *" ${host} "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Goose runs on Pi upstream platform.
+ga_graphify_upstream_platform() {
+  local host="${1:-}"
+  case "$host" in
+    goose) printf 'pi' ;;
+    *) printf '%s' "$host" ;;
+  esac
+}
+
+ga_abs_export_path() {
+  local repo="${1:-}"
+  if [[ -n "$repo" ]]; then
+    printf '%s/.agentmemory' "${repo%/}"
+  else
+    printf '%s' "${GA_DEFAULT_EXPORT_FALLBACK}"
+  fi
+}
+
+ga_host_config_present() {
+  local host="${1:-}"
+  case "$host" in
+    claude) [[ -f "${HOME}/.claude.json" ]] ;;
+    codex) [[ -f "${HOME}/.codex/config.toml" ]] ;;
+    opencode) [[ -f "${HOME}/.config/opencode/opencode.json" ]] ;;
+    goose) [[ -f "${HOME}/.config/goose/config.yaml" ]] || [[ -d "${HOME}/.pi/agent" ]] ;;
+    hermes) [[ -f "${HOME}/.hermes/config.yaml" ]] || [[ -d "${HOME}/.hermes" ]] ;;
+    *) return 1 ;;
+  esac
+}
+
+ga_graphify_pre_commands() {
+  local host="${1:-}"
+  local platform
+  platform="$(ga_graphify_upstream_platform "$host")"
+  case "$host" in
+    claude) printf '%s\n' 'graphify install' ;;
+    codex|opencode|hermes|goose)
+      printf '%s\n' "graphify install --platform ${platform}"
+      ;;
+  esac
+}
+
+ga_graphify_post_commands() {
+  local host="${1:-}"
+  local platform
+  platform="$(ga_graphify_upstream_platform "$host")"
+  case "$host" in
+    claude) printf '%s\n' 'graphify claude install' ;;
+    codex) printf '%s\n' 'graphify codex install' ;;
+    opencode) printf '%s\n' 'graphify opencode install' ;;
+    hermes) printf '%s\n' 'graphify hermes install' ;;
+    goose) printf '%s\n' 'graphify pi install' ;;
+  esac
+}
+
+ga_agentmemory_commands() {
+  local host="${1:-}"
+  case "$host" in
+    claude) printf '%s\n' 'agentmemory connect claude-code' ;;
+    codex)
+      printf '%s\n' \
+        'codex plugin marketplace add rohitg00/agentmemory' \
+        'codex plugin add agentmemory@agentmemory' \
+        'agentmemory connect codex --with-hooks'
+      ;;
+    goose) printf '%s\n' 'agentmemory connect pi' ;;
+    hermes) printf '%s\n' 'agentmemory connect hermes' ;;
+    opencode) ;;
+  esac
+}
+
+ga_graphify_global_artifact_path() {
+  local host="${1:-}"
+  case "$host" in
+    claude) printf '%s/.claude/skills/graphify/SKILL.md' "${HOME}" ;;
+    codex) printf '%s/.codex/skills/graphify/SKILL.md' "${HOME}" ;;
+    opencode) printf '%s/.config/opencode/opencode.json' "${HOME}" ;;
+    goose) printf '%s/.pi/agent/skills/graphify/SKILL.md' "${HOME}" ;;
+    hermes) printf '%s/.hermes/skills/graphify/SKILL.md' "${HOME}" ;;
+    *) return 1 ;;
+  esac
+}
+
+ga_agentmemory_global_artifact_path() {
+  local host="${1:-}"
+  case "$host" in
+    claude) printf '%s/.claude.json' "${HOME}" ;;
+    codex) printf '%s/.codex/config.toml' "${HOME}" ;;
+    opencode) printf '%s/.config/opencode/opencode.json' "${HOME}" ;;
+    goose) printf '%s/.config/goose/config.yaml' "${HOME}" ;;
+    hermes) printf '%s/.hermes/config.yaml' "${HOME}" ;;
+    *) return 1 ;;
+  esac
+}
+
+ga_graphify_artifact_present() {
+  local host="${1:-}" artifact
+  artifact="$(ga_graphify_global_artifact_path "$host" 2>/dev/null || true)"
+  [[ -n "$artifact" && -f "$artifact" ]] || return 1
+  grep -q 'graphify' "$artifact" 2>/dev/null
+}
+
+ga_agentmemory_artifact_present() {
+  local host="${1:-}" artifact
+  artifact="$(ga_agentmemory_global_artifact_path "$host" 2>/dev/null || true)"
+  [[ -n "$artifact" && -f "$artifact" ]] || return 1
+  grep -q 'agentmemory' "$artifact" 2>/dev/null
+}
+
+ga_merge_agentmemory_env() {
+  local arg="${1:-}"
+  local export_abs
+  if [[ "$arg" == */.agentmemory ]]; then
+    export_abs="$arg"
+  elif [[ -n "$arg" ]]; then
+    export_abs="$(ga_abs_export_path "$arg")"
+  else
+    export_abs="$(ga_abs_export_path "")"
+  fi
+  local am_home env_file
+  am_home="$(ga_agentmemory_home)"
+  env_file="${am_home}/.env"
+  mkdir -p "$am_home"
+  local template="# === graphify-am synergy_max managed block ===
+AGENTMEMORY_INJECT_CONTEXT=true
+AGENTMEMORY_AUTO_COMPRESS=false
+CONSOLIDATION_ENABLED=false
+OBSIDIAN_AUTO_EXPORT=true
+CLAUDE_MEMORY_BRIDGE=true
+AGENTMEMORY_EXPORT_ROOT=${export_abs}
+# === end graphify-am synergy_max managed block ==="
+  if ga_dry_run; then
+    printf 'DRY-RUN: merge %s (backup .env.bak)\n' "$env_file"
+    return 0
+  fi
+  [[ -f "$env_file" ]] && cp "$env_file" "${env_file}.bak"
+  if [[ -f "$env_file" ]] && grep -q '# === graphify-am synergy_max managed block ===' "$env_file"; then
+    local tmp
+    tmp="$(mktemp)"
+    awk '
+      /^# === graphify-am synergy_max managed block ===/ { skip=1; next }
+      /^# === end graphify-am synergy_max managed block ===/ { skip=0; next }
+      skip==0 { print }
+    ' "$env_file" >"$tmp"
+    mv "$tmp" "$env_file"
+  fi
+  printf '\n%s\n' "$template" >>"$env_file"
+  chmod 600 "$env_file" 2>/dev/null || true
+}
+
+ga_opencode_merge_agentmemory_mcp() {
+  local cfg="${HOME}/.config/opencode/opencode.json"
+  mkdir -p "$(dirname "$cfg")"
+  if ga_dry_run; then
+    printf 'DRY-RUN: merge agentmemory MCP into %s\n' "$cfg"
+    return 0
+  fi
+  if [[ ! -f "$cfg" ]]; then
+    printf '{"$schema":"https://opencode.ai/config.json","mcp":{"agentmemory":{"type":"stdio","command":"npx","args":["-y","@agentmemory/mcp"],"env":{"AGENTMEMORY_URL":"http://localhost:3111"}}}}\n' >"$cfg"
+    return 0
+  fi
+  command -v jq >/dev/null 2>&1 || return 1
+  local tmp
+  tmp="$(mktemp)"
+  jq '.mcp.agentmemory = {
+    "type": "stdio",
+    "command": "npx",
+    "args": ["-y", "@agentmemory/mcp"],
+    "env": { "AGENTMEMORY_URL": "http://localhost:3111" }
+  }' "$cfg" >"$tmp" && mv "$tmp" "$cfg"
+}
+
+ga_launchd_server_plist() {
+  local export_abs="${1:-$(ga_abs_export_path "")}"
+  local am_home node_path plist_dir plist_path
+  am_home="$(ga_agentmemory_home)"
+  node_path="$(command -v node 2>/dev/null || printf '%s' /usr/local/bin/node)"
+  plist_dir="${HOME}/Library/LaunchAgents"
+  plist_path="${plist_dir}/com.agentmemory.server.plist"
+  mkdir -p "$plist_dir"
+  if ga_dry_run; then
+    printf 'DRY-RUN: write %s\n' "$plist_path"
+    return 0
+  fi
+  local am_bin
+  am_bin="$(command -v agentmemory 2>/dev/null || printf '%s' "${HOME}/.npm-global/bin/agentmemory")"
+  cat >"$plist_path" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.agentmemory.server</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${node_path}</string>
+    <string>${am_bin}</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AGENTMEMORY_EXPORT_ROOT</key>
+    <string>${export_abs}</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${am_home}/server.log</string>
+  <key>StandardErrorPath</key>
+  <string>${am_home}/server.log</string>
+</dict>
+</plist>
+EOF
+  launchctl bootout "gui/$(id -u)/com.agentmemory.server" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "$plist_path" 2>/dev/null \
+    || launchctl load "$plist_path" 2>/dev/null || true
+}
+
+ga_launchd_bridge_plist() {
+  local repo="${1:-}"
+  [[ -n "$repo" ]] || return 0
+  local bridge_script python_path plist_dir plist_path
+  bridge_script="$(ga_agentmemory_home)/bridge.py"
+  [[ -f "$bridge_script" ]] || return 0
+  python_path="$(command -v python3 2>/dev/null || printf '%s' /usr/bin/python3)"
+  plist_dir="${HOME}/Library/LaunchAgents"
+  plist_path="${plist_dir}/com.agentmemory.bridge.plist"
+  mkdir -p "$plist_dir" "${repo}/.agentmemory"
+  if ga_dry_run; then
+    printf 'DRY-RUN: write %s\n' "$plist_path"
+    return 0
+  fi
+  cat >"$plist_path" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.agentmemory.bridge</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${python_path}</string>
+    <string>${bridge_script}</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AGENTMEMORY_REPO_ROOT</key>
+    <string>${repo}</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${repo}/.agentmemory/bridge.log</string>
+  <key>StandardErrorPath</key>
+  <string>${repo}/.agentmemory/bridge.log</string>
+</dict>
+</plist>
+EOF
+  launchctl bootout "gui/$(id -u)/com.agentmemory.bridge" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "$plist_path" 2>/dev/null \
+    || launchctl load "$plist_path" 2>/dev/null || true
+}
+
+ga_graphify_cli_available() {
+  command -v graphify >/dev/null 2>&1
+}
+
+ga_agentmemory_cli_available() {
+  command -v agentmemory >/dev/null 2>&1
+}
+
+ga_agentmemory_server_healthy() {
+  command -v curl >/dev/null 2>&1 \
+    && curl -sf "http://localhost:3111/agentmemory/health" >/dev/null 2>&1
+}
+
+ga_graphify_hooks_installed() {
+  command -v graphify >/dev/null 2>&1 || return 1
+  graphify hook status 2>/dev/null | grep -qiE 'installed|active|enabled'
+}
+
+ga_run_cmd() {
+  local cmd="$1"
+  if ga_dry_run; then
+    printf 'DRY-RUN: %s\n' "$cmd"
+    return 0
+  fi
+  eval "$cmd" 2>/dev/null || true
+}
+
+ga_apply_shared_agentmemory() {
+  local repo="${1:-}"
+  local export_abs
+  export_abs="$(ga_abs_export_path "$repo")"
+  mkdir -p "$export_abs/memory" "$export_abs/snapshots"
+  if command -v agentmemory >/dev/null 2>&1; then
+    ga_run_cmd 'agentmemory init'
+  fi
+  ga_merge_agentmemory_env "$export_abs"
+  if ! ga_skip_host_hooks && command -v launchctl >/dev/null 2>&1; then
+    ga_launchd_server_plist "$export_abs"
+    ga_launchd_bridge_plist "$repo"
+  fi
+}
+
+ga_apply_graphify_host() {
+  local host="${1:-}"
+  ga_graphify_cli_available || return 0
+  local cmd
+  while IFS= read -r cmd; do
+    [[ -n "$cmd" ]] || continue
+    ga_run_cmd "$cmd"
+  done < <(ga_graphify_pre_commands "$host")
+  while IFS= read -r cmd; do
+    [[ -n "$cmd" ]] || continue
+    ga_run_cmd "$cmd"
+  done < <(ga_graphify_post_commands "$host")
+  if ! ga_skip_host_hooks; then
+    ga_run_cmd 'graphify hook install'
+  fi
+}
+
+ga_apply_agentmemory_host() {
+  local host="${1:-}"
+  ga_agentmemory_cli_available || return 0
+  local cmd
+  while IFS= read -r cmd; do
+    [[ -n "$cmd" ]] || continue
+    ga_run_cmd "$cmd"
+  done < <(ga_agentmemory_commands "$host")
+  if [[ "$host" == "opencode" ]]; then
+    ga_opencode_merge_agentmemory_mcp
+  fi
+}
+
+ga_apply_host() {
+  local host="${1:-}" repo="${2:-}"
+  printf '== graphify-am global apply (host=%s, profile=%s) ==\n' "$host" "$GA_DEFAULT_PROFILE"
+  ga_apply_shared_agentmemory "$repo"
+  ga_apply_graphify_host "$host"
+  ga_apply_agentmemory_host "$host"
+  if [[ -n "$repo" ]] && ga_graphify_cli_available; then
+  if ga_dry_run; then
+    printf 'DRY-RUN: graphify update %s --no-cluster\n' "$repo"
+  else
+    (cd "$repo" && graphify update . --no-cluster) 2>/dev/null || true
+  fi
+  fi
+}
+
+ga_verify_host() {
+  local host="${1:-}" repo="${2:-}"
+  local fails=0 warns=0 pass=0
+  local report=""
+
+  _ga_check() {
+    local status="$1" label="$2" detail="$3"
+    case "$status" in
+      pass) pass=$((pass + 1)); report+="  [x] ${label}: ${detail}\n" ;;
+      warn) warns=$((warns + 1)); report+="  [!] ${label}: ${detail}\n" ;;
+      fail) fails=$((fails + 1)); report+="  [ ] ${label}: ${detail}\n" ;;
+    esac
+  }
+
+  if ga_graphify_cli_available; then
+    _ga_check pass graphify-cli "$(command -v graphify)"
+  else
+    _ga_check fail graphify-cli "not on PATH — uv tool install graphifyy"
+  fi
+
+  if ga_agentmemory_cli_available; then
+    _ga_check pass agentmemory-cli "$(command -v agentmemory)"
+  else
+    _ga_check fail agentmemory-cli "not on PATH — npm install -g @agentmemory/agentmemory"
+  fi
+
+  if ga_agentmemory_server_healthy; then
+    _ga_check pass agentmemory-server "http://localhost:3111/agentmemory/health"
+  else
+    _ga_check fail agentmemory-server "not healthy — launch agentmemory or check launchd"
+  fi
+
+  local env_file
+  env_file="$(ga_agentmemory_home)/.env"
+  if [[ -f "$env_file" ]] && grep -q 'AGENTMEMORY_INJECT_CONTEXT=true' "$env_file" 2>/dev/null; then
+    _ga_check pass agentmemory-env "synergy_max flags in ${env_file}"
+  else
+    _ga_check warn agentmemory-env "missing synergy_max block — run --apply"
+  fi
+
+  if ga_graphify_artifact_present "$host"; then
+    _ga_check pass graphify-platform "${host} artifact wired"
+  else
+    _ga_check warn graphify-platform "missing $(ga_graphify_global_artifact_path "$host" 2>/dev/null || echo artifact)"
+  fi
+
+  if [[ "$host" == "opencode" ]]; then
+    if ga_agentmemory_artifact_present "$host"; then
+      _ga_check pass agentmemory-platform "opencode MCP in opencode.json"
+    else
+      _ga_check warn agentmemory-platform "merge agentmemory MCP — run --apply"
+    fi
+  elif ga_agentmemory_artifact_present "$host"; then
+    _ga_check pass agentmemory-platform "${host} config references agentmemory"
+  else
+    _ga_check warn agentmemory-platform "missing $(ga_agentmemory_global_artifact_path "$host" 2>/dev/null || echo config)"
+  fi
+
+  if ga_graphify_hooks_installed; then
+    _ga_check pass graphify-hooks "git template hooks installed"
+  else
+    _ga_check warn graphify-hooks "run graphify hook install"
+  fi
+
+  if [[ -n "$repo" && -f "${repo}/graphify-out/graph.json" ]]; then
+    _ga_check pass graphify-index "index at ${repo}/graphify-out/graph.json"
+  elif [[ -n "$repo" ]]; then
+    _ga_check warn graphify-index "no index — cd ${repo} && graphify update . --no-cluster"
+  fi
+
+  export GA_VERIFY_PASS="$pass"
+  export GA_VERIFY_FAILS="$fails"
+  export GA_VERIFY_WARNS="$warns"
+  export GA_VERIFY_REPORT="$report"
+  printf '== graphify-am verify (host=%s) ==\n' "$host"
+  printf '%b' "$report"
+  printf 'Summary: %s passed, %s failed, %s warnings\n' "$pass" "$fails" "$warns"
+  [[ "$fails" -eq 0 ]]
+}
+
+ga_detect_configured_hosts() {
+  local host
+  for host in $GA_SUPPORTED_HOSTS; do
+    if ga_host_config_present "$host"; then
+      printf '%s\n' "$host"
+    fi
+  done
+}

--- a/hooks/lib/recommended-tools.sh
+++ b/hooks/lib/recommended-tools.sh
@@ -110,11 +110,21 @@ sb_recommended_tool_install_commands() {
   jq -r --arg id "$tool_id" '.recommended_tools[$id].install_commands[]? // empty' "$config_file" 2>/dev/null || true
 }
 
-# Host detection — mirrors hooks/lib/runtime-paths.sh (claude | codex | cursor).
+# Map SB host id → graphify upstream platform name (goose runs on Pi).
+sb_graphify_upstream_platform() {
+  local host="${1:-}"
+  host="${host:-$(sb_runtime_host)}"
+  case "$host" in
+    goose) printf 'pi' ;;
+    *) printf '%s' "$host" ;;
+  esac
+}
+
+# Host detection — mirrors hooks/lib/runtime-paths.sh.
 sb_runtime_host() {
   if [[ -n "${SILVER_BULLET_RUNTIME:-}" ]]; then
     case "$SILVER_BULLET_RUNTIME" in
-      claude|codex|cursor) printf '%s' "$SILVER_BULLET_RUNTIME"; return 0 ;;
+      claude|codex|cursor|opencode|goose|hermes) printf '%s' "$SILVER_BULLET_RUNTIME"; return 0 ;;
     esac
   fi
   if [[ -n "${CODEX_CI:-}" || -n "${CODEX_THREAD_ID:-}" || -n "${CODEX_INTERNAL_ORIGINATOR_OVERRIDE:-}" ]]; then
@@ -165,6 +175,9 @@ sb_recommended_tool_platform_pre_index_commands() {
     case "$host" in
       claude) printf '%s\n' 'graphify install --project' ;;
       codex) printf '%s\n' 'graphify install --project --platform codex' ;;
+      opencode) printf '%s\n' 'graphify install --project --platform opencode' ;;
+      goose) printf '%s\n' 'graphify install --project --platform pi' ;;
+      hermes) printf '%s\n' 'graphify install --project --platform hermes' ;;
     esac
   elif [[ "$tool_id" == "agentmemory" ]]; then
     case "$host" in
@@ -213,7 +226,7 @@ sb_recommended_tool_platform_post_index_commands() {
   if [[ -n "$legacy" ]]; then
     case "$host" in
       cursor) printf '%s' "$legacy"; return 0 ;;
-      claude|codex)
+      claude|codex|opencode|goose|hermes)
         printf '%s' "$legacy" | tail -n 1
         return 0
         ;;
@@ -224,11 +237,17 @@ sb_recommended_tool_platform_post_index_commands() {
       cursor) printf '%s\n' 'graphify cursor install' ;;
       claude) printf '%s\n' 'graphify claude install --project' ;;
       codex) printf '%s\n' 'graphify codex install --project' ;;
+      opencode|goose|hermes) ;;
     esac
   elif [[ "$tool_id" == "agentmemory" ]]; then
     case "$host" in
       claude) printf '%s\n' 'agentmemory connect claude-code' ;;
       codex) printf '%s\n' 'agentmemory connect codex --with-hooks' ;;
+      goose) printf '%s\n' 'agentmemory connect pi' ;;
+      hermes) printf '%s\n' 'agentmemory connect hermes' ;;
+      opencode)
+        printf '%s\n' 'Merge agentmemory MCP into ~/.config/opencode/opencode.json (manual — see docs/AGENTMEMORY.md)'
+        ;;
     esac
   elif [[ "$tool_id" == "context_mode" ]]; then
     case "$host" in
@@ -243,6 +262,9 @@ sb_graphify_platform_artifact_path() {
   case "$host" in
     cursor) printf '%s/.cursor/rules/graphify.mdc' "${project_root%/}" ;;
     codex) printf '%s/.codex/hooks.json' "${project_root%/}" ;;
+    opencode) printf '%s/.opencode/opencode.json' "${project_root%/}" ;;
+    goose) printf '%s/.pi/agent/skills/graphify/SKILL.md' "${project_root%/}" ;;
+    hermes) printf '%s/AGENTS.md' "${project_root%/}" ;;
     *) printf '%s/.claude/settings.json' "${project_root%/}" ;;
   esac
 }
@@ -254,8 +276,7 @@ sb_graphify_platform_artifact_present() {
   artifact="$(sb_graphify_platform_artifact_path "$project_root" "$host")"
   [[ -f "$artifact" && ! -L "$artifact" ]] || return 1
   case "$host" in
-    cursor) grep -q 'graphify' "$artifact" 2>/dev/null ;;
-    codex) grep -q 'graphify' "$artifact" 2>/dev/null ;;
+    cursor|codex|claude|opencode|goose|hermes) grep -q 'graphify' "$artifact" 2>/dev/null ;;
     *) grep -q 'graphify' "$artifact" 2>/dev/null ;;
   esac
 }

--- a/hooks/lib/runtime-paths.sh
+++ b/hooks/lib/runtime-paths.sh
@@ -18,7 +18,7 @@ if [[ -z "${SILVER_BULLET_RUNTIME:-}" ]]; then
 fi
 
 case "$SILVER_BULLET_RUNTIME" in
-  claude|codex|cursor) ;;
+  claude|codex|cursor|opencode|goose|hermes) ;;
   *) SILVER_BULLET_RUNTIME="claude" ;;
 esac
 
@@ -27,7 +27,12 @@ _sb_runtime_base_home="${HOME}"
 if [[ "$SB_RUNTIME_NAME" == "codex" && -n "${KAY_HOME:-}" ]]; then
   _sb_runtime_base_home="${KAY_HOME}"
 fi
-SB_RUNTIME_HOME_ROOT="${_sb_runtime_base_home}/.${SB_RUNTIME_NAME}"
+case "$SB_RUNTIME_NAME" in
+  opencode) SB_RUNTIME_HOME_ROOT="${HOME}/.config/opencode" ;;
+  goose) SB_RUNTIME_HOME_ROOT="${HOME}/.config/goose" ;;
+  hermes) SB_RUNTIME_HOME_ROOT="${HOME}/.hermes" ;;
+  *) SB_RUNTIME_HOME_ROOT="${_sb_runtime_base_home}/.${SB_RUNTIME_NAME}" ;;
+esac
 # Tests/hooks may pin state dir via SB_RUNTIME_STATE_DIR when SB_RUNTIME_PRESERVE_STATE_DIR=1.
 if [[ "${SB_RUNTIME_PRESERVE_STATE_DIR:-}" == "1" && -n "${SB_RUNTIME_STATE_DIR:-}" ]]; then
   :

--- a/plugins/silver-bullet/templates/silver-bullet.config.json.default
+++ b/plugins/silver-bullet/templates/silver-bullet.config.json.default
@@ -172,9 +172,27 @@
           "post_index": [
             "graphify cursor install"
           ]
+        },
+        "opencode": {
+          "pre_index": [
+            "graphify install --project --platform opencode"
+          ],
+          "post_index": []
+        },
+        "goose": {
+          "pre_index": [
+            "graphify install --project --platform pi"
+          ],
+          "post_index": []
+        },
+        "hermes": {
+          "pre_index": [
+            "graphify install --project --platform hermes"
+          ],
+          "post_index": []
         }
       },
-      "benefits_summary": "Scoped retrieval saves tokens; team-shared knowledge graph indexes code and docs; portable across Claude, Codex, and Cursor agents.",
+      "benefits_summary": "Scoped retrieval saves tokens; team-shared knowledge graph indexes code and docs; portable across Claude, Codex, Cursor, OpenCode, Goose (Pi), and Hermes agents.",
       "graph_path": "graphify-out/graph.json",
       "query_ttl_seconds": 1800,
       "query_budget": 2000,
@@ -215,6 +233,24 @@
           "pre_index": [],
           "post_index": [
             "Verify agentmemory MCP is configured in $HOME/.codex/mcp.json (see docs/AGENTMEMORY.md)"
+          ]
+        },
+        "opencode": {
+          "pre_index": [],
+          "post_index": [
+            "Merge agentmemory MCP into ~/.config/opencode/opencode.json mcp section (manual — no agentmemory connect opencode; see docs/AGENTMEMORY.md)"
+          ]
+        },
+        "goose": {
+          "pre_index": [],
+          "post_index": [
+            "agentmemory connect pi (manual TS extension copy per integrations/pi.md; Goose uses Pi runtime)"
+          ]
+        },
+        "hermes": {
+          "pre_index": [],
+          "post_index": [
+            "agentmemory connect hermes (manual YAML merge per integrations/hermes.md)"
           ]
         }
       },

--- a/plugins/silver-bullet/templates/silver-bullet.md.base
+++ b/plugins/silver-bullet/templates/silver-bullet.md.base
@@ -333,9 +333,9 @@ lifts hook blocks until the next init/update retry succeeds.
    substantive work is blocked until the index exists.
 3. After CLI install, run platform registration from the project root in upstream order (detect host via
    `SILVER_BULLET_RUNTIME`, `CURSOR_PLUGIN_ROOT`, or Codex env vars):
-   - **Pre-index skill:** Claude `graphify install --project`; Codex `graphify install --project --platform codex`; Cursor skip
+   - **Pre-index skill:** Claude `graphify install --project`; Codex `graphify install --project --platform codex`; OpenCode `graphify install --project --platform opencode`; Goose `graphify install --project --platform pi`; Hermes `graphify install --project --platform hermes`; Cursor skip
    - **Index:** `graphify update . --no-cluster`
-   - **Post-index always-on:** Claude `graphify claude install --project`; Codex `graphify codex install --project`; Cursor `graphify cursor install` (writes `.cursor/rules/graphify.mdc`)
+   - **Post-index always-on:** Claude `graphify claude install --project`; Codex `graphify codex install --project`; Cursor `graphify cursor install` (writes `.cursor/rules/graphify.mdc`); OpenCode/Goose/Hermes use project skill + hooks or `AGENTS.md` (see `docs/GRAPHIFY.md`)
    - **Optional:** `graphify hook install` for auto-rebuild on commit
 
 **When opted out or consent pending:**

--- a/scripts/graphify-am-global-setup.sh
+++ b/scripts/graphify-am-global-setup.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# graphify-am-global-setup.sh — SB-independent global Graphify + agentmemory synergy_max setup.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LIB="${REPO_ROOT}/hooks/lib/graphify-am-global.sh"
+
+MODE="apply"
+HOST=""
+REPO_PATH=""
+DRY_RUN=0
+APPLY_ALL=0
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/graphify-am-global-setup.sh --host HOST [--apply|--verify] [options]
+
+Global (user/machine-level) Graphify + agentmemory setup using synergy_max profile.
+Does NOT require Silver Bullet, /silver:init, .silver-bullet.json, or SB hooks.
+
+Hosts: claude | codex | opencode | goose | hermes | all
+
+Options:
+  --host HOST   Target agent host (required unless documenting defaults)
+  --apply       Apply idempotent global wiring (default)
+  --verify      Scorecard only; exit 1 on critical failures
+  --repo PATH   Optional project root for AGENTMEMORY_EXPORT_ROOT, bridge, index
+  --all         With --apply/--verify: run for every host with detected global config
+  --dry-run     Print actions without mutating files
+  -h, --help    Show help
+
+Examples:
+  bash scripts/graphify-am-global-setup.sh --host claude --apply
+  bash scripts/graphify-am-global-setup.sh --host codex --verify
+  bash scripts/graphify-am-global-setup.sh --host claude --apply --repo ~/projects/my-app
+  bash scripts/graphify-am-global-setup.sh --host all --verify
+
+Export root without --repo: ~/.agentmemory/default-export (override per project with --repo).
+Git hooks: graphify hook install (global git template — applies to new repos).
+See docs/graphify-am/PLATFORM-MATRIX.md and docs/graphify-am/verification/.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host)
+      shift
+      HOST="${1:-}"
+      [[ "$HOST" == "all" ]] && APPLY_ALL=1
+      ;;
+    --apply) MODE="apply" ;;
+    --verify) MODE="verify" ;;
+    --repo)
+      shift
+      REPO_PATH="${1:-}"
+      REPO_PATH="$(cd "$REPO_PATH" 2>/dev/null && pwd || printf '%s' "$REPO_PATH")"
+      ;;
+    --all) APPLY_ALL=1 ;;
+    --dry-run) DRY_RUN=1; export GA_GLOBAL_DRY_RUN=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+# shellcheck source=../hooks/lib/graphify-am-global.sh
+source "$LIB"
+
+if [[ -z "$HOST" && "$APPLY_ALL" -eq 0 ]]; then
+  echo "Error: --host is required (claude|codex|opencode|goose|hermes|all)" >&2
+  usage >&2
+  exit 2
+fi
+
+run_for_host() {
+  local h="${1:-}"
+  ga_validate_host "$h" || {
+    echo "Unsupported host: $h" >&2
+    return 2
+  }
+  case "$MODE" in
+    apply) ga_apply_host "$h" "$REPO_PATH" ;;
+    verify) ga_verify_host "$h" "$REPO_PATH" ;;
+  esac
+}
+
+if [[ "$APPLY_ALL" -eq 1 ]]; then
+  rc=0
+  mapfile -t detected < <(ga_detect_configured_hosts)
+  if [[ "${#detected[@]}" -eq 0 ]]; then
+    echo "No configured hosts detected (checked global config paths)." >&2
+    exit 1
+  fi
+  for h in "${detected[@]}"; do
+    run_for_host "$h" || rc=1
+    echo ""
+  done
+  exit "$rc"
+fi
+
+if [[ "$HOST" == "all" ]]; then
+  APPLY_ALL=1
+  mapfile -t detected < <(ga_detect_configured_hosts)
+  if [[ "${#detected[@]}" -eq 0 ]]; then
+    echo "No configured hosts detected." >&2
+    exit 1
+  fi
+  rc=0
+  for h in "${detected[@]}"; do
+    run_for_host "$h" || rc=1
+    echo ""
+  done
+  exit "$rc"
+fi
+
+ga_validate_host "$HOST" || {
+  echo "Unsupported host: $HOST (use: ${GA_SUPPORTED_HOSTS})" >&2
+  exit 2
+}
+
+run_for_host "$HOST"

--- a/scripts/graphify-am-global-setup.sh
+++ b/scripts/graphify-am-global-setup.sh
@@ -9,7 +9,6 @@ LIB="${REPO_ROOT}/hooks/lib/graphify-am-global.sh"
 MODE="apply"
 HOST=""
 REPO_PATH=""
-DRY_RUN=0
 APPLY_ALL=0
 
 usage() {
@@ -57,7 +56,7 @@ while [[ $# -gt 0 ]]; do
       REPO_PATH="$(cd "$REPO_PATH" 2>/dev/null && pwd || printf '%s' "$REPO_PATH")"
       ;;
     --all) APPLY_ALL=1 ;;
-    --dry-run) DRY_RUN=1; export GA_GLOBAL_DRY_RUN=1 ;;
+    --dry-run) export GA_GLOBAL_DRY_RUN=1 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac

--- a/scripts/sb-optimize-stack.sh
+++ b/scripts/sb-optimize-stack.sh
@@ -8,10 +8,11 @@ LIB="${REPO_ROOT}/hooks/lib/stack-optimizer.sh"
 
 MODE="apply"
 DRY_RUN=0
+HOST_OVERRIDE=""
 
 usage() {
   cat <<'EOF'
-Usage: bash scripts/sb-optimize-stack.sh [--apply|--verify|--report] [--dry-run]
+Usage: bash scripts/sb-optimize-stack.sh [--apply|--verify|--report] [--dry-run] [--host HOST]
 
 Applies or verifies the synergy_max Graphify + agentmemory optimization profile
 when both tools are opted in via recommended_tools.*.enabled_by_user.
@@ -21,6 +22,7 @@ Options:
   --verify    Scorecard only; exit 1 on critical gaps when opted in
   --report    Markdown summary to stdout
   --dry-run   Print actions without mutating host/project files
+  --host HOST Override runtime host (claude|codex|cursor|opencode|goose|hermes)
   -h, --help  Show help
 
 Skips host-level hooks when CI=true. See docs/STACK-OPTIMIZATION.md.
@@ -33,6 +35,10 @@ while [[ $# -gt 0 ]]; do
     --verify) MODE="verify" ;;
     --report) MODE="report" ;;
     --dry-run) DRY_RUN=1; export SB_STACK_OPTIMIZER_DRY_RUN=1 ;;
+    --host)
+      shift
+      HOST_OVERRIDE="${1:-}"
+      ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -45,6 +51,9 @@ source "$LIB"
 CONFIG="${REPO_ROOT}/.silver-bullet.json"
 [[ -f "$CONFIG" ]] || CONFIG="${REPO_ROOT}/templates/silver-bullet.config.json.default"
 
+if [[ -n "$HOST_OVERRIDE" ]]; then
+  export SILVER_BULLET_RUNTIME="$HOST_OVERRIDE"
+fi
 HOST="$(sb_runtime_host)"
 PROFILE="$(sb_stack_optimization_profile_name "$CONFIG")"
 

--- a/silver-bullet.md
+++ b/silver-bullet.md
@@ -333,9 +333,9 @@ lifts hook blocks until the next init/update retry succeeds.
    substantive work is blocked until the index exists.
 3. After CLI install, run platform registration from the project root in upstream order (detect host via
    `SILVER_BULLET_RUNTIME`, `CURSOR_PLUGIN_ROOT`, or Codex env vars):
-   - **Pre-index skill:** Claude `graphify install --project`; Codex `graphify install --project --platform codex`; Cursor skip
+   - **Pre-index skill:** Claude `graphify install --project`; Codex `graphify install --project --platform codex`; OpenCode `graphify install --project --platform opencode`; Goose `graphify install --project --platform pi`; Hermes `graphify install --project --platform hermes`; Cursor skip
    - **Index:** `graphify update . --no-cluster`
-   - **Post-index always-on:** Claude `graphify claude install --project`; Codex `graphify codex install --project`; Cursor `graphify cursor install` (writes `.cursor/rules/graphify.mdc`)
+   - **Post-index always-on:** Claude `graphify claude install --project`; Codex `graphify codex install --project`; Cursor `graphify cursor install` (writes `.cursor/rules/graphify.mdc`); OpenCode/Goose/Hermes use project skill + hooks or `AGENTS.md` (see `docs/GRAPHIFY.md`)
    - **Optional:** `graphify hook install` for auto-rebuild on commit
 
 **When opted out or consent pending:**

--- a/templates/silver-bullet.config.json.default
+++ b/templates/silver-bullet.config.json.default
@@ -172,9 +172,27 @@
           "post_index": [
             "graphify cursor install"
           ]
+        },
+        "opencode": {
+          "pre_index": [
+            "graphify install --project --platform opencode"
+          ],
+          "post_index": []
+        },
+        "goose": {
+          "pre_index": [
+            "graphify install --project --platform pi"
+          ],
+          "post_index": []
+        },
+        "hermes": {
+          "pre_index": [
+            "graphify install --project --platform hermes"
+          ],
+          "post_index": []
         }
       },
-      "benefits_summary": "Scoped retrieval saves tokens; team-shared knowledge graph indexes code and docs; portable across Claude, Codex, and Cursor agents.",
+      "benefits_summary": "Scoped retrieval saves tokens; team-shared knowledge graph indexes code and docs; portable across Claude, Codex, Cursor, OpenCode, Goose (Pi), and Hermes agents.",
       "graph_path": "graphify-out/graph.json",
       "query_ttl_seconds": 1800,
       "query_budget": 2000,
@@ -215,6 +233,24 @@
           "pre_index": [],
           "post_index": [
             "Verify agentmemory MCP is configured in ~/.cursor/mcp.json (see docs/AGENTMEMORY.md)"
+          ]
+        },
+        "opencode": {
+          "pre_index": [],
+          "post_index": [
+            "Merge agentmemory MCP into ~/.config/opencode/opencode.json mcp section (manual — no agentmemory connect opencode; see docs/AGENTMEMORY.md)"
+          ]
+        },
+        "goose": {
+          "pre_index": [],
+          "post_index": [
+            "agentmemory connect pi (manual TS extension copy per integrations/pi.md; Goose uses Pi runtime)"
+          ]
+        },
+        "hermes": {
+          "pre_index": [],
+          "post_index": [
+            "agentmemory connect hermes (manual YAML merge per integrations/hermes.md)"
           ]
         }
       },

--- a/templates/silver-bullet.md.base
+++ b/templates/silver-bullet.md.base
@@ -333,9 +333,9 @@ lifts hook blocks until the next init/update retry succeeds.
    substantive work is blocked until the index exists.
 3. After CLI install, run platform registration from the project root in upstream order (detect host via
    `SILVER_BULLET_RUNTIME`, `CURSOR_PLUGIN_ROOT`, or Codex env vars):
-   - **Pre-index skill:** Claude `graphify install --project`; Codex `graphify install --project --platform codex`; Cursor skip
+   - **Pre-index skill:** Claude `graphify install --project`; Codex `graphify install --project --platform codex`; OpenCode `graphify install --project --platform opencode`; Goose `graphify install --project --platform pi`; Hermes `graphify install --project --platform hermes`; Cursor skip
    - **Index:** `graphify update . --no-cluster`
-   - **Post-index always-on:** Claude `graphify claude install --project`; Codex `graphify codex install --project`; Cursor `graphify cursor install` (writes `.cursor/rules/graphify.mdc`)
+   - **Post-index always-on:** Claude `graphify claude install --project`; Codex `graphify codex install --project`; Cursor `graphify cursor install` (writes `.cursor/rules/graphify.mdc`); OpenCode/Goose/Hermes use project skill + hooks or `AGENTS.md` (see `docs/GRAPHIFY.md`)
    - **Optional:** `graphify hook install` for auto-rebuild on commit
 
 **When opted out or consent pending:**

--- a/tests/hooks/test-agentmemory-platform-install.sh
+++ b/tests/hooks/test-agentmemory-platform-install.sh
@@ -36,7 +36,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 echo "=== agentmemory platform install contract tests ==="
 
-for host in claude codex cursor; do
+for host in claude codex cursor opencode goose hermes; do
   if jq -e --arg h "$host" '.recommended_tools.agentmemory.platform_install_commands[$h]' "$TEMPLATE" >/dev/null 2>&1; then
     pass "template has platform_install_commands.${host}"
   else
@@ -68,6 +68,9 @@ source "$REPO_ROOT/hooks/lib/agentmemory-gate.sh"
 [[ "$(SILVER_BULLET_RUNTIME=cursor sb_agentmemory_platform_artifact_path "$TMP")" == "${HOME}/.cursor/mcp.json" ]] && pass "cursor artifact path" || fail "cursor artifact path"
 [[ "$(SILVER_BULLET_RUNTIME=claude sb_agentmemory_platform_artifact_path "$TMP")" == "${HOME}/.claude.json" ]] && pass "claude artifact path" || fail "claude artifact path"
 [[ "$(SILVER_BULLET_RUNTIME=codex sb_agentmemory_platform_artifact_path "$TMP")" == "${HOME}/.codex/config.toml" ]] && pass "codex artifact path" || fail "codex artifact path"
+[[ "$(SILVER_BULLET_RUNTIME=opencode sb_agentmemory_platform_artifact_path "$TMP")" == "${HOME}/.config/opencode/opencode.json" ]] && pass "opencode artifact path" || fail "opencode artifact path"
+[[ "$(SILVER_BULLET_RUNTIME=hermes sb_agentmemory_platform_artifact_path "$TMP")" == "${HOME}/.hermes/config.yaml" ]] && pass "hermes artifact path" || fail "hermes artifact path"
+[[ "$(SILVER_BULLET_RUNTIME=goose sb_agentmemory_platform_artifact_path "$TMP")" == "${HOME}/.config/goose/config.yaml" ]] && pass "goose artifact path" || fail "goose artifact path"
 
 assert_grep "silver-init agentmemory section" "$REPO_ROOT/skills/silver-init/SKILL.md" "### 1.1b agentmemory"
 assert_grep "silver-update agentmemory retry" "$REPO_ROOT/skills/silver-update/SKILL.md" "Step 8b: agentmemory"

--- a/tests/hooks/test-graphify-platform-install.sh
+++ b/tests/hooks/test-graphify-platform-install.sh
@@ -37,7 +37,7 @@ trap 'rm -rf "$TMP"' EXIT
 echo "=== graphify platform install contract tests ==="
 
 # Template schema: pre_index / post_index per host
-for host in claude codex cursor; do
+for host in claude codex cursor opencode goose hermes; do
   if jq -e --arg h "$host" '.recommended_tools.graphify.platform_install_commands[$h]' "$TEMPLATE" >/dev/null 2>&1; then
     pass "template has platform_install_commands.${host}"
   else
@@ -53,6 +53,15 @@ claude_pre="$(jq -r '.recommended_tools.graphify.platform_install_commands.claud
 
 codex_pre="$(jq -r '.recommended_tools.graphify.platform_install_commands.codex.pre_index[0]' "$TEMPLATE")"
 [[ "$codex_pre" == "graphify install --project --platform codex" ]] && pass "codex pre_index skill install" || fail "codex pre_index"
+
+opencode_pre="$(jq -r '.recommended_tools.graphify.platform_install_commands.opencode.pre_index[0]' "$TEMPLATE")"
+[[ "$opencode_pre" == "graphify install --project --platform opencode" ]] && pass "opencode pre_index" || fail "opencode pre_index"
+
+goose_pre="$(jq -r '.recommended_tools.graphify.platform_install_commands.goose.pre_index[0]' "$TEMPLATE")"
+[[ "$goose_pre" == "graphify install --project --platform pi" ]] && pass "goose pre_index uses pi platform" || fail "goose pre_index"
+
+hermes_pre="$(jq -r '.recommended_tools.graphify.platform_install_commands.hermes.pre_index[0]' "$TEMPLATE")"
+[[ "$hermes_pre" == "graphify install --project --platform hermes" ]] && pass "hermes pre_index" || fail "hermes pre_index"
 
 install_cmds="$(jq -r '.recommended_tools.graphify.install_commands[]' "$TEMPLATE")"
 printf '%s' "$install_cmds" | grep -q 'uv tool install graphifyy' && pass "template CLI uv install" || fail "template CLI uv install"

--- a/tests/hooks/test-recommended-tools.sh
+++ b/tests/hooks/test-recommended-tools.sh
@@ -80,9 +80,12 @@ printf '%s' "$claude_cmds" | grep -q 'graphify install --project' && pass "claud
 printf '%s' "$claude_cmds" | grep -q 'graphify claude install --project' && pass "claude always-on install from config" || fail "claude always-on install from config"
 [[ "$(SILVER_BULLET_RUNTIME=claude sb_recommended_tool_platform_pre_index_commands "$TMP/.silver-bullet.json" graphify)" == "graphify install --project" ]] && pass "claude pre_index from nested config" || fail "claude pre_index from nested config"
 
-[[ "$(SILVER_BULLET_RUNTIME=cursor sb_runtime_host)" == "cursor" ]] && pass "sb_runtime_host cursor" || fail "sb_runtime_host cursor"
 [[ "$(SILVER_BULLET_RUNTIME=codex sb_runtime_host)" == "codex" ]] && pass "sb_runtime_host codex" || fail "sb_runtime_host codex"
 [[ "$(SILVER_BULLET_RUNTIME=claude sb_runtime_host)" == "claude" ]] && pass "sb_runtime_host claude" || fail "sb_runtime_host claude"
+[[ "$(SILVER_BULLET_RUNTIME=opencode sb_runtime_host)" == "opencode" ]] && pass "sb_runtime_host opencode" || fail "sb_runtime_host opencode"
+[[ "$(SILVER_BULLET_RUNTIME=goose sb_runtime_host)" == "goose" ]] && pass "sb_runtime_host goose" || fail "sb_runtime_host goose"
+[[ "$(SILVER_BULLET_RUNTIME=hermes sb_runtime_host)" == "hermes" ]] && pass "sb_runtime_host hermes" || fail "sb_runtime_host hermes"
+[[ "$(SILVER_BULLET_RUNTIME=goose sb_graphify_upstream_platform)" == "pi" ]] && pass "goose maps to pi upstream" || fail "goose maps to pi upstream"
 host="$(
   env -u SILVER_BULLET_RUNTIME -u CODEX_CI -u CODEX_THREAD_ID -u CODEX_INTERNAL_ORIGINATOR_OVERRIDE     CURSOR_PLUGIN_ROOT=/x/.cursor/plugins bash -c "source '$LIB'; sb_runtime_host"
 )"

--- a/tests/scripts/test-graphify-am-global-setup.sh
+++ b/tests/scripts/test-graphify-am-global-setup.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Contract tests for graphify-am-global-setup.sh — no SB fixture required.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/graphify-am-global-setup.sh"
+LIB="${REPO_ROOT}/hooks/lib/graphify-am-global.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== graphify-am-global-setup tests ==="
+
+[[ -f "$SCRIPT" ]] && pass "script exists" || fail "script exists"
+chmod +x "$SCRIPT" 2>/dev/null || true
+[[ -x "$SCRIPT" ]] && pass "script executable" || fail "script executable"
+
+[[ -f "$LIB" ]] && pass "lib exists" || fail "lib exists"
+
+# shellcheck source=../../hooks/lib/graphify-am-global.sh
+source "$LIB"
+
+ga_validate_host claude && pass "host claude valid" || fail "host claude valid"
+ga_validate_host codex && pass "host codex valid" || fail "host codex valid"
+ga_validate_host opencode && pass "host opencode valid" || fail "host opencode valid"
+ga_validate_host goose && pass "host goose valid" || fail "host goose valid"
+ga_validate_host hermes && pass "host hermes valid" || fail "host hermes valid"
+ga_validate_host cursor && fail "cursor rejected" || pass "cursor rejected (not in global hosts)"
+
+[[ "$(ga_graphify_upstream_platform goose)" == "pi" ]] && pass "goose maps to pi" || fail "goose maps to pi"
+
+pre="$(ga_graphify_pre_commands claude)"
+[[ "$pre" == "graphify install" ]] && pass "claude global pre-index" || fail "claude global pre-index: $pre"
+
+post="$(ga_graphify_post_commands claude)"
+[[ "$post" == "graphify claude install" ]] && pass "claude global post-index" || fail "claude global post-index: $post"
+
+codex_pre="$(ga_graphify_pre_commands codex)"
+printf '%s' "$codex_pre" | grep -q 'graphify install --platform codex' && pass "codex global pre-index" || fail "codex global pre-index"
+
+goose_post="$(ga_graphify_post_commands goose)"
+[[ "$goose_post" == "graphify pi install" ]] && pass "goose global post-index" || fail "goose global post-index: $goose_post"
+
+am_claude="$(ga_agentmemory_commands claude)"
+[[ "$am_claude" == "agentmemory connect claude-code" ]] && pass "claude agentmemory cmd" || fail "claude agentmemory cmd"
+
+# Help and dry-run (no SB config)
+bash "$SCRIPT" --help >/dev/null 2>&1 && pass "--help exits 0" || fail "--help exits 0"
+
+if GA_SKIP_HOST_HOOKS=1 bash "$SCRIPT" --host claude --apply --dry-run >/dev/null 2>&1; then
+  pass "dry-run --apply exits 0"
+else
+  fail "dry-run --apply exits 0"
+fi
+
+if ! bash "$SCRIPT" --host invalid --verify 2>/dev/null; then
+  pass "invalid host exits non-zero"
+else
+  fail "invalid host exits non-zero"
+fi
+
+# Env merge without SB
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+GA_AGENTMEMORY_HOME="$TMP/amhome" ga_merge_agentmemory_env "/tmp/project"
+grep -q 'AGENTMEMORY_INJECT_CONTEXT=true' "$TMP/amhome/.env" && pass "env merge inject_context" || fail "env merge inject_context"
+grep -q 'AGENTMEMORY_EXPORT_ROOT=/tmp/project/.agentmemory' "$TMP/amhome/.env" && pass "env absolute export" || fail "env absolute export"
+
+# Verification docs exist
+for host in claude codex opencode goose hermes; do
+  doc="${REPO_ROOT}/docs/graphify-am/verification/${host}-verify-graphify-am.md"
+  [[ -f "$doc" ]] && pass "verification doc ${host}" || fail "verification doc ${host}"
+done
+
+[[ -f "${REPO_ROOT}/docs/graphify-am/PLATFORM-MATRIX.md" ]] && pass "platform matrix doc" || fail "platform matrix doc"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/scripts/test-sb-optimize-stack.sh
+++ b/tests/scripts/test-sb-optimize-stack.sh
@@ -80,5 +80,9 @@ grep -q "AGENTMEMORY_EXPORT_ROOT=.*/.agentmemory" "$TMP/amhome/.env" && pass "en
 
 grep -q 'sb-optimize-stack' "$REPO_ROOT/docs/STACK-OPTIMIZATION.md" && pass "STACK-OPTIMIZATION.md exists" || fail "STACK-OPTIMIZATION.md"
 
+grep -q '\-\-host HOST' "$SCRIPT" && pass "script supports --host" || fail "script supports --host"
+SILVER_BULLET_RUNTIME=hermes bash "$SCRIPT" --apply --dry-run --host hermes >/dev/null 2>&1 \
+  && pass "dry-run --host hermes" || fail "dry-run --host hermes"
+
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- Extend `synergy_max` stack optimizer with platform support for **OpenCode**, **Goose** (Pi upstream), and **Hermes** alongside existing Claude/Codex/Cursor paths.
- Add `platform_install_commands` to the SB template, `--host` override on `sb-optimize-stack.sh`, host detection/artifact paths, and contract tests.
- Add per-agent verification addenda under `docs/graphify-am/verification/` (Phase 1–4 + Manual Step 7.5 prompts).
- Include SB-independent global setup helper (`graphify-am-global-setup.sh`) and platform matrix doc for hosts without `/silver:init`.

## Platform support matrix

| Host | Graphify | agentmemory |
|------|----------|-------------|
| Claude | Yes (`connect` automated) | Yes |
| Codex | Yes | Yes (`connect codex --with-hooks`) |
| Cursor | Yes | Yes (MCP manual verify) |
| OpenCode | Yes (`install --platform opencode`) | **Manual MCP** in `opencode.json` |
| Goose | Yes (maps to `pi` platform) | **Manual** `connect pi` TS extension |
| Hermes | Yes (`install --platform hermes`) | **Manual** YAML merge |

## Test plan

- [x] `bash tests/hooks/test-graphify-platform-install.sh`
- [x] `bash tests/hooks/test-agentmemory-platform-install.sh`
- [x] `bash tests/hooks/test-recommended-tools.sh`
- [x] `bash tests/scripts/test-sb-optimize-stack.sh`
- [x] `bash tests/integration/test-synergy-optimization.sh`
- [x] `bash tests/scripts/test-graphify-am-global-setup.sh`
- [ ] CI full suite on PR

## Apply per host

```bash
SILVER_BULLET_RUNTIME=<host> bash scripts/sb-optimize-stack.sh --apply --host <host>
```


Made with [Cursor](https://cursor.com)