### PR TITLE
feat(agentmemory): require gitleaks alongside bridge secret scanning

### DIFF
--- a/agents/claude/silver-init/SKILL.md
+++ b/agents/claude/silver-init/SKILL.md
@@ -327,6 +327,13 @@ Add agentmemory gitignore block if missing (see `docs/AGENTMEMORY.md`).
 
 Read `recommended_tools.agentmemory.platform_install_commands.<host>` from config when present.
 
+**Step 3e — gitleaks (required with bridge):**
+```bash
+command -v gitleaks || brew install gitleaks   # macOS
+command -v gitleaks && gitleaks version
+```
+The bridge uses regex first, then gitleaks as a second-line scan (JWTs and other patterns regex skips). SB optimizer installs gitleaks and sets `GITLEAKS_PATH` in the bridge launchd plist when `synergy_max` runs.
+
 **On full success**, clear suspension:
 ```bash
 jq '.recommended_tools.agentmemory.enforcement_suspended = false

--- a/agents/claude/silver-update/SKILL.md
+++ b/agents/claude/silver-update/SKILL.md
@@ -248,6 +248,7 @@ test -f .silver-bullet.json && jq -r '.recommended_tools.agentmemory.enforcement
    - **Codex:** `agentmemory connect codex --with-hooks`
    - **Cursor:** merge MCP block per `docs/AGENTMEMORY.md` (Cursor MCP config)
 5. Scaffold: `mkdir -p .agentmemory/memory .agentmemory/snapshots`
+6. **gitleaks:** `command -v gitleaks || brew install gitleaks` (macOS); verify with `gitleaks version`. Required for bridge second-line secret scan — SB optimizer also installs via `sb-optimize-stack.sh --apply`.
 
 On success, clear suspension (same jq pattern as Graphify). On failure, keep suspension.
 

--- a/agents/codex/silver-init/SKILL.md
+++ b/agents/codex/silver-init/SKILL.md
@@ -328,6 +328,13 @@ Add agentmemory gitignore block if missing (see `docs/AGENTMEMORY.md`).
 
 Read `recommended_tools.agentmemory.platform_install_commands.<host>` from config when present.
 
+**Step 3e — gitleaks (required with bridge):**
+```bash
+command -v gitleaks || brew install gitleaks   # macOS
+command -v gitleaks && gitleaks version
+```
+The bridge uses regex first, then gitleaks as a second-line scan (JWTs and other patterns regex skips). SB optimizer installs gitleaks and sets `GITLEAKS_PATH` in the bridge launchd plist when `synergy_max` runs.
+
 **On full success**, clear suspension:
 ```bash
 jq '.recommended_tools.agentmemory.enforcement_suspended = false

--- a/agents/codex/silver-update/SKILL.md
+++ b/agents/codex/silver-update/SKILL.md
@@ -249,6 +249,7 @@ test -f .silver-bullet.json && jq -r '.recommended_tools.agentmemory.enforcement
    - **Codex:** `agentmemory connect codex --with-hooks`
    - **Cursor:** merge MCP block per `docs/AGENTMEMORY.md` (Cursor MCP config)
 5. Scaffold: `mkdir -p .agentmemory/memory .agentmemory/snapshots`
+6. **gitleaks:** `command -v gitleaks || brew install gitleaks` (macOS); verify with `gitleaks version`. Required for bridge second-line secret scan — SB optimizer also installs via `sb-optimize-stack.sh --apply`.
 
 On success, clear suspension (same jq pattern as Graphify). On failure, keep suspension.
 

--- a/agents/cursor/silver-init/SKILL.md
+++ b/agents/cursor/silver-init/SKILL.md
@@ -327,6 +327,13 @@ Add agentmemory gitignore block if missing (see `docs/AGENTMEMORY.md`).
 
 Read `recommended_tools.agentmemory.platform_install_commands.<host>` from config when present.
 
+**Step 3e — gitleaks (required with bridge):**
+```bash
+command -v gitleaks || brew install gitleaks   # macOS
+command -v gitleaks && gitleaks version
+```
+The bridge uses regex first, then gitleaks as a second-line scan (JWTs and other patterns regex skips). SB optimizer installs gitleaks and sets `GITLEAKS_PATH` in the bridge launchd plist when `synergy_max` runs.
+
 **On full success**, clear suspension:
 ```bash
 jq '.recommended_tools.agentmemory.enforcement_suspended = false

--- a/agents/cursor/silver-update/SKILL.md
+++ b/agents/cursor/silver-update/SKILL.md
@@ -248,6 +248,7 @@ test -f .silver-bullet.json && jq -r '.recommended_tools.agentmemory.enforcement
    - **Codex:** `agentmemory connect codex --with-hooks`
    - **Cursor:** merge MCP block per `docs/AGENTMEMORY.md` (Cursor MCP config)
 5. Scaffold: `mkdir -p .agentmemory/memory .agentmemory/snapshots`
+6. **gitleaks:** `command -v gitleaks || brew install gitleaks` (macOS); verify with `gitleaks version`. Required for bridge second-line secret scan — SB optimizer also installs via `sb-optimize-stack.sh --apply`.
 
 On success, clear suspension (same jq pattern as Graphify). On failure, keep suspension.
 

--- a/docs/AGENTMEMORY.md
+++ b/docs/AGENTMEMORY.md
@@ -67,7 +67,19 @@ CLAUDE_MEMORY_BRIDGE=true
 AGENTMEMORY_EXPORT_ROOT=/absolute/path/to/project/.agentmemory
 ```
 
-**launchd (macOS):** `com.agentmemory.server` with `KeepAlive` and absolute export root in plist env (see `SETUP_REPORT.md` deviations). **Bridge:** `com.agentmemory.bridge` watches `.agentmemory/` when `~/.agentmemory/bridge.py` exists.
+**launchd (macOS):** `com.agentmemory.server` with `KeepAlive` and absolute export root in plist env (see `SETUP_REPORT.md` deviations). **Bridge:** `com.agentmemory.bridge` watches `.agentmemory/` when `~/.agentmemory/bridge.py` exists. The bridge plist includes `GITLEAKS_PATH` and `PATH` so the second-line gitleaks scan runs reliably.
+
+### gitleaks (required with bridge)
+
+The bridge scans exports with regex first, then **gitleaks** as a second line (catches JWTs and other patterns the regex list deliberately skips). Install before or during stack optimization:
+
+```bash
+brew install gitleaks          # macOS
+gitleaks version
+# Linux: apt install gitleaks or GitHub releases — see docs/STACK-OPTIMIZATION.md
+```
+
+When agentmemory is opted in, `sb-optimize-stack.sh --apply` and `graphify-am-global-setup.sh --apply` attempt install, verify `which gitleaks`, and write `GITLEAKS_PATH` into `com.agentmemory.bridge` launchd env. Diagnostics warn when gitleaks is missing.
 
 **Injection tradeoff:** `INJECT_CONTEXT=true` improves recall but increases token cost. Use future `cost_minimized` profile to disable.
 

--- a/docs/STACK-OPTIMIZATION.md
+++ b/docs/STACK-OPTIMIZATION.md
@@ -47,7 +47,7 @@ Configured in `.silver-bullet.json` under `optimization_profiles.synergy_max`:
 | **Persistence** | macOS launchd `com.agentmemory.server` + `com.agentmemory.bridge`; Linux systemd user units when available |
 | **Project** | `.agentmemory/memory/**` scaffold, gitignore `/**` negation fix |
 | **Synergy** | Obsidian export trigger + post-export `graphify update`; verify graph contains `.agentmemory` refs |
-| **Advisory** | `brew install gitleaks` when missing |
+| **gitleaks** | Required with bridge — `brew install gitleaks` (macOS) or apt on Linux; `GITLEAKS_PATH` in bridge launchd plist |
 
 ## Consent and safety
 
@@ -68,7 +68,7 @@ Configured in `.silver-bullet.json` under `optimization_profiles.synergy_max`:
 
 Critical failures (exit non-zero on `--verify` when opted in): missing CLI, index, server health, synergy graph refs.
 
-Warnings (non-blocking): missing git hooks, bridge, gitleaks, launchd.
+Warnings (non-blocking): missing git hooks, bridge, gitleaks (when required), launchd.
 
 ## Platform matrix
 

--- a/docs/graphify-am/PLATFORM-MATRIX.md
+++ b/docs/graphify-am/PLATFORM-MATRIX.md
@@ -20,11 +20,12 @@
 |------|----------------|-------|
 | Graphify CLI | `uv tool install graphifyy` or `pipx install graphifyy` | Python 3.10+ |
 | agentmemory CLI | `npm install -g @agentmemory/agentmemory` | Node 20+ |
+| **gitleaks** | `brew install gitleaks` (macOS) or `apt install gitleaks` (Linux) | Required for bridge second-line secret scan |
 | synergy_max `.env` | `~/.agentmemory/.env` | Script merges managed block; chmod 600 |
 | Server persistence | macOS: `~/Library/LaunchAgents/com.agentmemory.server.plist` | Linux: systemd user unit (manual) |
 | Git hooks | `graphify hook install` | Global git template — new repos inherit |
 | Export root (default) | `~/.agentmemory/default-export` | Override with `--repo /path/to/project` |
-| Bridge (optional) | `com.agentmemory.bridge` launchd | Only when `--repo` passed and `~/.agentmemory/bridge.py` exists |
+| Bridge (optional) | `com.agentmemory.bridge` launchd | Only when `--repo` passed and `~/.agentmemory/bridge.py` exists; requires gitleaks on PATH |
 
 ## Synergy loop (per project)
 

--- a/docs/graphify-am/verification/claude-verify-graphify-am.md
+++ b/docs/graphify-am/verification/claude-verify-graphify-am.md
@@ -28,6 +28,16 @@ which agentmemory && agentmemory --version 2>/dev/null | head -1
 
 **Fail:** `npm install -g @agentmemory/agentmemory`
 
+### 1.3 gitleaks
+
+```bash
+which gitleaks && gitleaks version 2>/dev/null | head -1
+```
+
+**Pass:** binary on PATH (bridge second-line secret scan).
+
+**Fail:** `brew install gitleaks` (macOS) or apt/GitHub releases on Linux — `graphify-am-global-setup.sh --apply` attempts install.
+
 ---
 
 ## Phase 2 — Global config artifacts
@@ -65,11 +75,10 @@ jq '.mcpServers | keys[]' ~/.claude.json 2>/dev/null | grep -i agentmemory
 ### 2.4 synergy_max `.env`
 
 ```bash
-grep AGENTMEMORY_INJECT_CONTEXT=true ~/.agentmemory/.env
-grep AGENTMEMORY_EXPORT_ROOT ~/.agentmemory/.env
+test -f ~/.agentmemory/.env && grep -q '^AGENTMEMORY_INJECT_CONTEXT=true' ~/.agentmemory/.env && grep -q '^AGENTMEMORY_EXPORT_ROOT=' ~/.agentmemory/.env && echo OK
 ```
 
-**Pass:** both lines present; export root is absolute.
+**Pass:** `OK` printed; `AGENTMEMORY_EXPORT_ROOT` value is absolute.
 
 **Fail:** `bash scripts/graphify-am-global-setup.sh --host claude --apply`
 
@@ -105,11 +114,17 @@ graphify hook status
 
 1. Open a git repo with code. Optionally pass `--repo` to global setup for export root.
 2. Ask Claude to **save a decision** via agentmemory MCP (e.g. "Remember: we use jq for all JSON in this repo").
-3. Trigger export: `curl -sf -X POST http://localhost:3111/agentmemory/obsidian/export -H 'Content-Type: application/json' -d '{"vaultDir":"'"$(grep AGENTMEMORY_EXPORT_ROOT ~/.agentmemory/.env | cut -d= -f2)"'/memory"}'`
+3. The `com.agentmemory.bridge` launch agent watches `.agentmemory/` and auto-commits memories to git — wait ~30s for the bridge to snapshot and commit, OR trigger a manual export constrained to the global agentmemory home:
+   ```bash
+   curl -sf -X POST http://localhost:3111/agentmemory/obsidian/export \
+     -H 'Content-Type: application/json' \
+     -d '{"vaultDir":"'"$HOME"'/.agentmemory/default-export/memory"}'
+   ```
+   > **API constraint:** `obsidian/export` rejects `vaultDir` outside `~/.agentmemory/`. To get memories into the repo's `.agentmemory/memory/` (the whitelisted git path), rely on the bridge auto-snapshot OR copy from `~/.agentmemory/default-export/memory/` into the repo's `.agentmemory/memory/`.
 4. From repo root: `graphify update . --no-cluster`
-5. `graphify query "jq JSON decision" --budget 2000` — result should include `.agentmemory` nodes.
+5. `graphify query "agentmemory vault" --budget 1500` — result should include `.agentmemory/memory/MOC.md` nodes.
 
-**Pass:** query returns memory-related nodes.
+**Pass:** query returns memory-related nodes (e.g. `agentmemory vault`, `MOC.md`, `Sessions`, `Memories`).
 
 ---
 

--- a/docs/graphify-am/verification/codex-verify-graphify-am.md
+++ b/docs/graphify-am/verification/codex-verify-graphify-am.md
@@ -1,82 +1,172 @@
 # Self-Verification: Graphify + agentmemory in Codex (Global)
 
-Machine-level audit for **OpenAI Codex CLI** — no Silver Bullet prerequisite.
+Machine-level audit for **OpenAI Codex CLI** — no Silver Bullet prerequisite. Produces a pass/fail report per check.
 
 **Setup script:** `bash scripts/graphify-am-global-setup.sh --host codex --apply`
+**Host detection:** `~/.codex/config.toml` exists ⇒ host is `codex`. Setup script skips silently otherwise.
 
 ---
 
-## Phase 1 — Pre-flight
+## Phase 1 — Pre-flight (read-only)
 
 ```bash
-which graphify && which agentmemory && which codex
+which graphify
+which agentmemory
+which codex
+which gitleaks && gitleaks version 2>/dev/null | head -1
 ```
 
-Install gaps: `uv tool install graphifyy`, `npm install -g @agentmemory/agentmemory`, Codex per upstream docs.
+**Pass:** all four binaries on PATH.
+
+**Fail (Graphify):** `uv tool install graphifyy` or `pipx install graphifyy`.
+**Fail (agentmemory):** `npm install -g @agentmemory/agentmemory`.
+**Fail (Codex):** install per upstream docs (`brew install --cask codex` or `npm i -g @openai/codex`).
+**Fail (gitleaks):** `brew install gitleaks` (macOS) — required for bridge second-line secret scan; global setup attempts install on `--apply`.
 
 ---
 
 ## Phase 2 — Global config artifacts
 
-### 2.1 Graphify skill + always-on
+### 2.1 Graphify skill (global)
 
 ```bash
-test -f ~/.codex/skills/graphify/SKILL.md 2>/dev/null || ls ~/.codex/skills/graphify/ 2>/dev/null
-grep -i graphify ~/.codex/AGENTS.md 2>/dev/null | head -2
+test -f ~/.codex/skills/graphify/SKILL.md && grep -q graphify ~/.codex/skills/graphify/SKILL.md && echo OK
 ```
 
-**Apply:** `graphify install --platform codex` then `graphify codex install` (no `--project`).
+**Pass:** `OK` printed — skill file exists and contains `graphify` content.
 
-### 2.2 agentmemory plugin + MCP
+**Fail:** `graphify install --platform codex`.
+
+### 2.2 Graphify always-on (Codex rules)
 
 ```bash
-grep -i agentmemory ~/.codex/config.toml
-codex plugin list 2>/dev/null | grep -i agentmemory
+test -f ~/.codex/AGENTS.md && grep -q graphify ~/.codex/AGENTS.md && echo OK
 ```
 
-**Apply:**
+**Pass:** `~/.codex/AGENTS.md` references `graphify` (written by `graphify codex install`).
+
+**Fail:** `graphify codex install`.
+
+### 2.3 agentmemory MCP server
+
+```bash
+grep -A2 '^\[mcp_servers\.agentmemory\]' ~/.codex/config.toml >/dev/null 2>&1 && \
+  grep -q '@agentmemory/mcp' ~/.codex/config.toml && \
+  grep -q 'AGENTMEMORY_URL\s*=' ~/.codex/config.toml && echo OK
+```
+
+**Pass:** `OK` — `[mcp_servers.agentmemory]` TOML table present, command args include `@agentmemory/mcp`, and `AGENTMEMORY_URL` env var is set.
+
+**Fail:** `agentmemory connect codex --with-hooks` (preferred — also wires hooks.json), or:
 
 ```bash
 codex plugin marketplace add rohitg00/agentmemory
 codex plugin add agentmemory@agentmemory
-agentmemory connect codex --with-hooks
 ```
 
-### 2.3 `multi_agent` feature (parallel extraction)
+### 2.4 agentmemory always-on hooks (Codex hooks.json)
 
 ```bash
-grep -E '^multi_agent\s*=\s*true' ~/.codex/config.toml
+jq -e '.hooks.PreToolUse // .hooks.UserPromptSubmit // .hooks.SessionStart' \
+  ~/.codex/hooks.json 2>/dev/null | grep -q agentmemory && echo OK
 ```
 
-**Fail:** add under `[features]`: `multi_agent = true`
+**Pass:** `OK` — at least one of `PreToolUse` / `UserPromptSubmit` / `SessionStart` invokes an agentmemory script.
 
-### 2.4 synergy_max `.env`
+**Fail:** `agentmemory connect codex --with-hooks` (re-applies the hooks layer idempotently).
+
+### 2.5 synergy_max `.env`
 
 ```bash
-grep AGENTMEMORY_INJECT_CONTEXT=true ~/.agentmemory/.env
+test -f ~/.agentmemory/.env && grep -q '^AGENTMEMORY_INJECT_CONTEXT=true' ~/.agentmemory/.env && grep -q '^AGENTMEMORY_EXPORT_ROOT=' ~/.agentmemory/.env && echo OK
 ```
+
+**Pass:** `OK` printed; `AGENTMEMORY_EXPORT_ROOT` value is absolute.
+
+**Fail:** `bash scripts/graphify-am-global-setup.sh --host codex --apply`.
 
 ---
 
-## Phase 3 — Server and hooks
+## Phase 3 — Server and persistence
+
+### 3.1 Health
 
 ```bash
-curl -sf http://localhost:3111/agentmemory/health
-graphify hook status
-launchctl list 2>/dev/null | grep com.agentmemory.server || true
+curl -sf http://localhost:3111/agentmemory/health | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])"
+```
+
+**Pass:** `healthy`.
+
+**Fail:** `nohup agentmemory > ~/.agentmemory/server.log 2>&1 &` or re-run global setup.
+
+### 3.2 launchd (macOS)
+
+```bash
+launchctl list 2>/dev/null | grep com.agentmemory.server
+```
+
+**Pass:** server PID listed. To enable auto-start at login:
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.agentmemory.server.plist
+```
+
+**Warn if missing:** the plist exists at `~/Library/LaunchAgents/com.agentmemory.server.plist` but is not loaded. Bootstrap it manually (see command above).
+
+### 3.3 Git hooks (global template)
+
+```bash
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 && graphify hook status
+```
+
+**Pass:** `post-commit` and `post-checkout` installed (run inside any repo).
+
+**Fail:** `graphify hook install` (writes to global `init.templateDir`).
+
+### 3.4 Codex bridge (project-bound)
+
+```bash
+launchctl list 2>/dev/null | grep com.agentmemory.bridge
+```
+
+**Pass:** bridge PID listed. The bridge auto-commits `.agentmemory/memory/` snapshots to the repo pointed at by `AGENTMEMORY_REPO_ROOT` in `~/Library/LaunchAgents/com.agentmemory.bridge.plist`.
+
+**Warn if missing:** bridge only applies when `--repo <path>` was passed to global setup. To enable later:
+
+```bash
+bash scripts/graphify-am-global-setup.sh --host codex --apply --repo /path/to/project
 ```
 
 ---
 
 ## Phase 4 — Manual synergy test (Codex UI)
 
-1. In a repo, use agentmemory tools to capture a short note.
-2. Export obsidian vault to `AGENTMEMORY_EXPORT_ROOT/memory`.
-3. `graphify update . --no-cluster`
-4. `graphify query "<note topic>" --budget 2000` — expect `.agentmemory` in results.
+1. Open a git repo with code. The repo's `.gitignore` must whitelist `.agentmemory/memory/`, `.agentmemory/snapshots/`, and `.agentmemory/profile.md` (Silver Bullet's `.gitignore` already does this in the managed block).
+2. In Codex, use agentmemory MCP tools to capture a short note (e.g. "we use jq for all JSON in this repo").
+3. Wait for the bridge (or trigger a manual export constrained to the global agentmemory home):
+
+   ```bash
+   curl -sf -X POST http://localhost:3111/agentmemory/obsidian/export \
+     -H 'Content-Type: application/json' \
+     -d '{"vaultDir":"'"$HOME"'/.agentmemory/default-export/memory"}'
+   ```
+
+   > **API constraint:** `obsidian/export` rejects `vaultDir` outside `~/.agentmemory/`. To get memories into the repo's `.agentmemory/memory/` (the whitelisted git path), rely on the `com.agentmemory.bridge` auto-snapshot OR copy from `~/.agentmemory/default-export/memory/` into the repo's `.agentmemory/memory/`.
+4. From repo root: `graphify update . --no-cluster`
+5. `graphify query "agentmemory vault" --budget 1500` — expect `.agentmemory/memory/MOC.md` nodes.
+
+**Pass:** query returns memory-related nodes (e.g. `agentmemory vault`, `MOC.md`, `Sessions`, `Memories`).
 
 ---
 
-## Appendix — If Silver Bullet is active
+## Appendix — If Silver Bullet is active in a repo
 
-`SILVER_BULLET_RUNTIME=codex bash scripts/sb-optimize-stack.sh --apply --host codex` adds project-level optimization when opted in. Global `~/.codex/config.toml` wiring is unchanged.
+- `SILVER_BULLET_RUNTIME=codex bash scripts/sb-optimize-stack.sh --apply --host codex` adds project-level optimization (gitignore block, index refresh, consent timestamps).
+- Hooks (`graphify-gate`, `agentmemory-gate`) apply only when `recommended_tools.*.enabled_by_user: true`.
+- Global setup remains authoritative for `~/.agentmemory/.env`, `~/.codex/config.toml` (MCP), and `~/.codex/hooks.json`.
+- Codex is in `multi_agent.identity_tags`; SB project wiring is opt-in, not required for global verification.
+
+## Notes
+
+- The verification doc mirrors the Claude Code verification doc 1:1 except for host-specific paths and command substitutions (`~/.codex/` vs `~/.claude/`, `[mcp_servers.X]` TOML vs JSON, `AGENTS.md` vs `CLAUDE.md`).
+- See `docs/graphify-am/PLATFORM-MATRIX.md` for the canonical install command set and artifact paths.

--- a/docs/graphify-am/verification/goose-verify-graphify-am.md
+++ b/docs/graphify-am/verification/goose-verify-graphify-am.md
@@ -1,19 +1,80 @@
 # Self-Verification: Graphify + agentmemory in Goose (Pi runtime, Global)
 
-Machine-level audit for **Block Goose** (Pi coding-agent runtime) — no Silver Bullet prerequisite.
+Machine-level audit for **Block Goose** — no Silver Bullet prerequisite. Produces a pass/fail report per check.
 
-Goose uses the **Pi** upstream platform for Graphify and `agentmemory connect pi`.
+> Goose runs on the **Pi** coding-agent runtime. Graphify installs via `--platform pi`, and `agentmemory connect pi` is the agentmemory wiring path.
 
 **Setup script:** `bash scripts/graphify-am-global-setup.sh --host goose --apply`
+**Host detection:** `~/.config/goose/config.yaml` exists OR `~/.pi/agent/` exists ⇒ host is `goose`. Setup script skips silently otherwise.
 
 ---
 
-## Phase 1 — Pre-flight
+## Phase 1 — Pre-flight (read-only)
+
+### 1.1 Graphify CLI
 
 ```bash
-which graphify && which agentmemory
-test -f ~/.config/goose/config.yaml && echo goose-config-ok
+which graphify && graphify --version 2>/dev/null | head -1
 ```
+
+**Pass:** binary on PATH.
+
+**Fail:** `uv tool install graphifyy` or `pipx install graphifyy`.
+
+### 1.2 agentmemory CLI
+
+```bash
+# Hardened probe — survives Homebrew-managed npm installs in non-interactive subshells
+# where `brew shellenv` hasn't been sourced (PATH may not include /opt/homebrew/bin).
+for bin in agentmemory \
+           "$(npm config get prefix 2>/dev/null)/bin/agentmemory" \
+           /opt/homebrew/bin/agentmemory \
+           /usr/local/bin/agentmemory \
+           "$HOME/.npm-global/bin/agentmemory"; do
+  [ -x "$bin" ] && { echo "$bin"; "$bin" --version 2>/dev/null | head -1; break; }
+done
+```
+
+**Pass:** an absolute path is printed and the version line is non-empty.
+
+**Fail (npm direct):** `npm install -g @agentmemory/agentmemory`.
+
+**Fail (Homebrew → npm, macOS):** `brew install @agentmemory/agentmemory` (or `brew tap … && brew install …` if not in core). Homebrew installs via npm and symlinks the CLI to `/opt/homebrew/bin/agentmemory`; remember to add `eval "$(/opt/homebrew/bin/brew shellenv)"` to `~/.zshrc` so the binary is on PATH in interactive shells.
+
+### 1.3 Goose CLI
+
+```bash
+which goose 2>/dev/null
+```
+
+**Pass:** binary on PATH.
+
+**Fail:** install per upstream docs.
+
+> **Warn (acceptable):** the Goose CLI is not required to PASS global setup. Pi runtime + config files alone are authoritative. The CLI is only needed to invoke Goose for the manual synergy test (Phase 4). The setup script writes to `~/.config/goose/config.yaml` and `~/.pi/agent/skills/` regardless.
+
+### 1.4 Goose / Pi home exists
+
+```bash
+test -f ~/.config/goose/config.yaml && echo goose-config-ok
+test -d ~/.pi/agent && echo pi-home-ok
+```
+
+**Pass:** at least one of `goose-config-ok` or `pi-home-ok` printed (Pi runtime alone is sufficient).
+
+**Fail:** install Goose or create the home directories manually.
+
+> **Phase 1.3 fallback when the Goose CLI is absent:** the doc accepts the missing CLI as a WARN because Pi runtime + the global config files (`~/.config/goose/config.yaml`, `~/.pi/agent/`) are authoritative. To exercise Phase 4 manually without the Goose CLI, drive `graphify update` and `graphify query` from a regular terminal inside the target repo (they read the same `graphify-out/graph.json` that Goose would consume). The CLI is only required to invoke Goose itself for the UI-based capture step.
+
+### 1.5 gitleaks
+
+```bash
+which gitleaks && gitleaks version 2>/dev/null | head -1
+```
+
+**Pass:** binary on PATH (bridge second-line secret scan).
+
+**Fail:** `brew install gitleaks` (macOS) — global setup attempts install on `--apply`.
 
 ---
 
@@ -25,42 +86,164 @@ test -f ~/.config/goose/config.yaml && echo goose-config-ok
 test -f ~/.pi/agent/skills/graphify/SKILL.md && grep -q graphify ~/.pi/agent/skills/graphify/SKILL.md && echo OK
 ```
 
-**Apply:** `graphify install --platform pi` && `graphify pi install`
+**Pass:** `OK` — skill file exists and contains graphify content.
+
+> Pi loads skills on demand from `~/.pi/agent/skills/`; no separate `settings.json` "always-on" hook is required. (Contrast with Claude/Codex/OpenCode, which write `CLAUDE.md` / `AGENTS.md` / `plugin` entries for always-on behavior.)
+
+**Fail:** `graphify install --platform pi`.
 
 ### 2.2 agentmemory (Pi extension)
 
 ```bash
-grep -i agentmemory ~/.config/goose/config.yaml 2>/dev/null
-agentmemory status 2>/dev/null | grep -i pi
+test -d ~/.pi/agent/extensions/agentmemory && \
+  test -f ~/.pi/agent/extensions/agentmemory/index.ts && \
+  test -f ~/.pi/agent/settings.json && \
+  grep -q 'agentmemory' ~/.pi/agent/settings.json 2>/dev/null && echo OK
 ```
 
-**Apply:** `agentmemory connect pi` (see agentmemory `integrations/pi.md`)
+**Pass:** `OK` — `~/.pi/agent/extensions/agentmemory/{index,security}.ts` are installed AND `~/.pi/agent/settings.json` references the extension.
+
+**Fail (manual install required — `agentmemory connect pi` is automated only for some agents):**
+
+```bash
+agentmemory connect pi          # prints step-by-step manual install instructions
+# Then:
+mkdir -p ~/.pi/agent/extensions/agentmemory
+# Copy integrations/pi/index.ts and integrations/pi/security.ts from the agentmemory repo
+# (https://github.com/rohitg00/agentmemory/tree/main/integrations/pi) to:
+#   ~/.pi/agent/extensions/agentmemory/
+# Then add to ~/.pi/agent/settings.json:
+#   { "extensions": ["~/.pi/agent/extensions/agentmemory"] }
+```
+
+> **Why manual?** As of agentmemory 0.9.27, `agentmemory connect pi` reports: *"pi uses a TypeScript extension file. Automated copy + register isn't implemented yet — manual install required."*
 
 ### 2.3 synergy_max `.env`
 
 ```bash
-grep AGENTMEMORY_INJECT_CONTEXT=true ~/.agentmemory/.env
+test -f ~/.agentmemory/.env && grep -q '^AGENTMEMORY_INJECT_CONTEXT=true' ~/.agentmemory/.env && grep -q '^AGENTMEMORY_EXPORT_ROOT=' ~/.agentmemory/.env && echo OK
 ```
+
+**Pass:** `OK` printed; `AGENTMEMORY_EXPORT_ROOT` value is absolute.
+
+**Fail:** `bash scripts/graphify-am-global-setup.sh --host goose --apply`.
+
+> **About duplicate keys in `~/.agentmemory/.env`:** the file commonly contains up to **three** copies of the same keys (`AGENTMEMORY_INJECT_CONTEXT`, `AGENTMEMORY_EXPORT_ROOT`, etc.):
+> 1. The **base template** at the top of the file (originally written by `agentmemory init` or by hand).
+> 2. The **SB synergy_max managed block** (`# === SB synergy_max managed block === … # === end SB synergy_max managed block ===`), written by `scripts/sb-optimize-stack.sh` and stripped/replaced idempotently on re-runs.
+> 3. The **graphify-am synergy_max managed block** (`# === graphify-am synergy_max managed block === … # === end graphify-am synergy_max managed block ===`), written by `scripts/graphify-am-global-setup.sh` and likewise idempotent.
+>
+> This is **expected and harmless**: shells and Node `dotenv` parsers use **last-write-wins** for duplicate keys, and all three sources agree on the values. The check above only needs the keys to be present at all. Run `awk -F= '/^[A-Z][A-Z_0-9]+=/ {c[$1]++} END {for (k in c) if (c[k]>1) print k"="c[k]"x"}' ~/.agentmemory/.env` to confirm the duplicate count.
 
 ---
 
-## Phase 3 — Server and hooks
+## Phase 3 — Server and persistence
+
+### 3.1 Health
 
 ```bash
-curl -sf http://localhost:3111/agentmemory/health
-graphify hook status
+curl -sf http://localhost:3111/agentmemory/health | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])"
+```
+
+**Pass:** `healthy`.
+
+**Fail:** `nohup agentmemory > ~/.agentmemory/server.log 2>&1 &` or re-run global setup.
+
+### 3.2 launchd (macOS)
+
+```bash
+launchctl list 2>/dev/null | grep com.agentmemory.server
+```
+
+**Pass:** server PID listed. To enable auto-start at login:
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.agentmemory.server.plist
+```
+
+**Warn if missing:** the plist exists at `~/Library/LaunchAgents/com.agentmemory.server.plist` but is not loaded. Bootstrap it manually.
+
+### 3.3 Git hooks (global template)
+
+```bash
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 && graphify hook status
+```
+
+**Pass:** `post-commit` and `post-checkout` installed (run inside any repo).
+
+**Fail:** `graphify hook install`.
+
+### 3.4 Bridge (project-bound)
+
+```bash
+# 3.4a — process running?
+launchctl list 2>/dev/null | grep com.agentmemory.bridge
+# 3.4b — AGENTMEMORY_REPO_ROOT actually set in the plist and points at an existing repo?
+plutil -extract EnvironmentVariables.AGENTMEMORY_REPO_ROOT raw ~/Library/LaunchAgents/com.agentmemory.bridge.plist 2>/dev/null && \
+  test -d "$(plutil -extract EnvironmentVariables.AGENTMEMORY_REPO_ROOT raw ~/Library/LaunchAgents/com.agentmemory.bridge.plist)/.git" && \
+  echo bridge-repo-ok
+```
+
+**Pass:** both `3.4a` shows a PID AND `3.4b` prints `bridge-repo-ok`. The bridge auto-commits `.agentmemory/memory/` snapshots to the repo at `AGENTMEMORY_REPO_ROOT`.
+
+**Warn if missing (3.4a):** bridge only applies when `--repo <path>` was passed to global setup. To enable later:
+
+```bash
+bash scripts/graphify-am-global-setup.sh --host goose --apply --repo /path/to/project
+```
+
+**Warn if missing (3.4b):** the plist exists and is loaded, but `AGENTMEMORY_REPO_ROOT` is unset, points outside the repo, or the repo has no `.git` directory. Re-bootstrap:
+
+```bash
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.agentmemory.bridge.plist 2>/dev/null
+bash scripts/graphify-am-global-setup.sh --host goose --apply --repo /path/to/project
 ```
 
 ---
 
 ## Phase 4 — Manual synergy test (Goose UI)
 
-1. In Goose, invoke graphify skill or run `graphify query` from a project terminal.
-2. Capture a note via agentmemory/Pi tools if exposed.
-3. Export, re-index, query — confirm memory nodes appear in graph.
+### 4.0 Pre-flight: `.gitignore` whitelist
+
+```bash
+# Repo .gitignore must whitelist these (otherwise the bridge's auto-commits are ignored):
+cd <repo> && grep -E '^\!\.agentmemory/(memory|snapshots|profile\.md)' .gitignore
+```
+
+**Pass:** all three lines present (`!.agentmemory/memory/`, `!.agentmemory/snapshots/`, `!.agentmemory/profile.md`). Silver Bullet-managed repos satisfy this via the `agentmemory managed block` in `.gitignore`.
+
+### 4.1–4.5 Manual flow
+
+1. Open a git repo with code. (The repo's `.gitignore` must whitelist `.agentmemory/memory/`, `.agentmemory/snapshots/`, and `.agentmemory/profile.md` — see 4.0.)
+2. In Goose, invoke the graphify skill (`/graphify`) and use the agentmemory extension to capture a short note (e.g. "we use jq for all JSON in this repo").
+3. Wait for the bridge, OR trigger a manual export. **The `vaultDir` must resolve to (or under) the path stored in `AGENTMEMORY_EXPORT_ROOT`** — which by default is the repo's `.agentmemory/`:
+
+   ```bash
+   curl -sf -X POST http://localhost:3111/agentmemory/obsidian/export \
+     -H 'Content-Type: application/json' \
+     -d '{"vaultDir":"'"$(grep '^AGENTMEMORY_EXPORT_ROOT=' ~/.agentmemory/.env | tail -1 | cut -d= -f2)"'/memory"}'
+   ```
+
+   > **API constraint (verified against agentmemory 0.9.27):** `obsidian/export` rejects `vaultDir` values that do not resolve to (or under) the configured `AGENTMEMORY_EXPORT_ROOT`. The error response is `"vaultDir must be inside <AGENTMEMORY_EXPORT_ROOT>"`. So the example above sources `AGENTMEMORY_EXPORT_ROOT` from `.env` (`tail -1` to handle the duplicate-key case noted in 2.3) and targets `${EXPORT_ROOT}/memory`. To get memories into the repo's `.agentmemory/memory/` (the whitelisted git path) without a manual export, rely on the `com.agentmemory.bridge` auto-snapshot — see Phase 3.4 for its `AGENTMEMORY_REPO_ROOT`.
+4. From repo root: `graphify update . --no-cluster`
+5. `graphify query "agentmemory vault" --budget 1500` — expect `.agentmemory/memory/MOC.md` nodes.
+
+**Pass:** query returns memory-related nodes (e.g. `agentmemory vault`, `MOC.md`, `Sessions`, `Memories`).
+
+> If the Goose CLI is not installed (Phase 1.3 warning), invoke `graphify update` and `graphify query` from a regular terminal — they read the same `graphify-out/graph.json`.
 
 ---
 
-## Appendix — If Silver Bullet is active
+## Appendix — If Silver Bullet is active in a repo
 
-SB maps host id `goose` → graphify platform `pi`. Project-level `.pi/agent/` artifacts may also exist; global `~/.pi/agent/skills/graphify/` takes precedence for new sessions.
+- SB maps host id `goose` → graphify platform `pi`. Project-level `.pi/agent/` artifacts may also exist; global `~/.pi/agent/skills/graphify/` takes precedence for new sessions.
+- `SILVER_BULLET_RUNTIME=goose bash scripts/sb-optimize-stack.sh --apply --host goose` adds project-level optimization (gitignore block, index refresh, consent timestamps) when opted in.
+- Hooks (`graphify-gate`, `agentmemory-gate`) apply only when `recommended_tools.*.enabled_by_user: true`.
+- Global setup remains authoritative for `~/.agentmemory/.env` and `~/.config/goose/config.yaml`.
+
+## Notes
+
+- Goose uses the **Pi** runtime upstream, so Graphify installs via `--platform pi` and writes the skill to `~/.pi/agent/skills/graphify/`. There is no separate "always-on" hook layer beyond the skill itself (Pi loads skills on demand).
+- The agentmemory extension is a **TypeScript module** at `~/.pi/agent/extensions/agentmemory/`, registered via `~/.pi/agent/settings.json`. Pi uses agentmemory's **native REST hooks** at `:3111` — no MCP required.
+- The verification doc mirrors the Claude/Codex/OpenCode verification docs 1:1 except for the skill-loading mechanism (Pi loads skills, others use rules/plugins) and the manual-install requirement for the agentmemory TypeScript extension.
+- See `docs/graphify-am/PLATFORM-MATRIX.md` for the canonical install command set and artifact paths.

--- a/docs/graphify-am/verification/hermes-verify-graphify-am.md
+++ b/docs/graphify-am/verification/hermes-verify-graphify-am.md
@@ -1,17 +1,63 @@
 # Self-Verification: Graphify + agentmemory in Hermes (Global)
 
-Machine-level audit for **Hermes** agent — no Silver Bullet prerequisite.
+Machine-level audit for **Hermes Agent** — no Silver Bullet prerequisite. Produces a pass/fail report per check.
 
 **Setup script:** `bash scripts/graphify-am-global-setup.sh --host hermes --apply`
+**Host detection:** `~/.hermes/config.yaml` exists OR `~/.hermes/` directory exists ⇒ host is `hermes`. Setup script skips silently otherwise.
 
 ---
 
-## Phase 1 — Pre-flight
+## Phase 1 — Pre-flight (read-only)
+
+### 1.1 Graphify CLI
 
 ```bash
-which graphify && which agentmemory
-test -d ~/.hermes && echo hermes-home-ok
+which graphify && graphify --version 2>/dev/null | head -1
 ```
+
+**Pass:** binary on PATH.
+
+**Fail:** `uv tool install graphifyy` or `pipx install graphifyy`.
+
+### 1.2 agentmemory CLI
+
+```bash
+which agentmemory && agentmemory --version 2>/dev/null | head -1
+```
+
+**Pass:** binary on PATH.
+
+**Fail:** `npm install -g @agentmemory/agentmemory`.
+
+### 1.3 Hermes CLI
+
+```bash
+which hermes 2>/dev/null
+```
+
+**Pass:** binary on PATH.
+
+**Fail:** install per upstream docs (`curl -fsSL https://install.hermes-agent.dev | sh` or similar).
+
+### 1.4 Hermes home exists
+
+```bash
+test -d ~/.hermes && echo OK
+```
+
+**Pass:** `OK` printed.
+
+**Fail:** install Hermes or create `~/.hermes/` manually.
+
+### 1.5 gitleaks
+
+```bash
+which gitleaks && gitleaks version 2>/dev/null | head -1
+```
+
+**Pass:** binary on PATH (bridge second-line secret scan).
+
+**Fail:** `brew install gitleaks` (macOS) — global setup attempts install on `--apply`.
 
 ---
 
@@ -20,47 +66,159 @@ test -d ~/.hermes && echo hermes-home-ok
 ### 2.1 Graphify skill
 
 ```bash
-test -f ~/.hermes/skills/graphify/SKILL.md && echo graphify-skill-ok
+test -f ~/.hermes/skills/graphify/SKILL.md && grep -q graphify ~/.hermes/skills/graphify/SKILL.md && echo OK
 ```
 
-**Apply:** `graphify install --platform hermes` && `graphify hermes install`
+**Pass:** `OK` — skill file exists and contains graphify content.
 
-### 2.2 agentmemory wiring
+> Hermes loads skills on demand from `~/.hermes/skills/`. There is no separate `CLAUDE.md` / `AGENTS.md` "always-on" hook — the skill itself is the wiring.
+
+**Fail:** `graphify install --platform hermes`.
+
+### 2.2 Graphify always-on (skill manifest)
 
 ```bash
-grep -i agentmemory ~/.hermes/config.yaml 2>/dev/null
-agentmemory status 2>/dev/null | grep -i hermes
+ls ~/.hermes/skills/graphify/.graphify_version 2>/dev/null && cat ~/.hermes/skills/graphify/.graphify_version 2>/dev/null
 ```
 
-**Apply:** `agentmemory connect hermes`
+**Pass:** version file present (e.g. `0.8.37`). This confirms the install wrote the skill to the **global** path, not the cwd.
 
-### 2.3 synergy_max `.env`
+**Warn if missing:** the upstream `graphify hermes install` may have written to `./.hermes/skills/` (cwd) instead of `~/.hermes/skills/` — same upstream bug as `codex install` / `opencode install`. If this happens, move the files:
 
 ```bash
-grep AGENTMEMORY_INJECT_CONTEXT=true ~/.agentmemory/.env
-grep AGENTMEMORY_EXPORT_ROOT ~/.agentmemory/.env
+mkdir -p ~/.hermes/skills/graphify
+mv ./.hermes/skills/graphify/* ~/.hermes/skills/graphify/
 ```
+
+### 2.3 agentmemory MCP (YAML merge)
+
+```bash
+grep -q '^\s*mcp_servers:' ~/.hermes/config.yaml 2>/dev/null && \
+  grep -A 10 '^\s*mcp_servers:' ~/.hermes/config.yaml 2>/dev/null | grep -q 'agentmemory:' && \
+  grep -A 10 '^\s*mcp_servers:' ~/.hermes/config.yaml 2>/dev/null | grep -q '@agentmemory/mcp' && \
+  echo OK
+```
+
+**Pass:** `OK` — `mcp_servers.agentmemory` block present with `command: npx` and `args: ["-y", "@agentmemory/mcp"]`.
+
+**Fail (manual YAML merge — `agentmemory connect hermes` reports "yaml-merge-not-implemented"):**
+
+```bash
+# Backup first
+cp ~/.hermes/config.yaml ~/.hermes/config.yaml.bak
+
+# Append (or merge with yq if installed) the agentmemory MCP block:
+cat >> ~/.hermes/config.yaml <<'YAML'
+
+mcp_servers:
+  agentmemory:
+    command: npx
+    args: ["-y", "@agentmemory/mcp"]
+
+memory:
+  provider: agentmemory
+YAML
+```
+
+> **Why manual?** As of agentmemory 0.9.27, `agentmemory connect hermes` reports: *"Hermes uses YAML config. Automated merge isn't implemented yet — manual install required."*
+
+### 2.4 synergy_max `.env`
+
+```bash
+test -f ~/.agentmemory/.env && grep -q '^AGENTMEMORY_INJECT_CONTEXT=true' ~/.agentmemory/.env && grep -q '^AGENTMEMORY_EXPORT_ROOT=' ~/.agentmemory/.env && echo OK
+```
+
+**Pass:** `OK` printed; `AGENTMEMORY_EXPORT_ROOT` value is absolute.
+
+**Fail:** `bash scripts/graphify-am-global-setup.sh --host hermes --apply`.
 
 ---
 
-## Phase 3 — Server and hooks
+## Phase 3 — Server and persistence
+
+### 3.1 Health
 
 ```bash
-curl -sf http://localhost:3111/agentmemory/health
-graphify hook status
-launchctl list 2>/dev/null | grep com.agentmemory.server || true
+curl -sf http://localhost:3111/agentmemory/health | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])"
+```
+
+**Pass:** `healthy`.
+
+**Fail:** `nohup agentmemory > ~/.agentmemory/server.log 2>&1 &` or re-run global setup.
+
+### 3.2 launchd (macOS)
+
+```bash
+launchctl list 2>/dev/null | grep com.agentmemory.server
+```
+
+**Pass:** server PID listed. To enable auto-start at login:
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.agentmemory.server.plist
+```
+
+**Warn if missing:** the plist exists at `~/Library/LaunchAgents/com.agentmemory.server.plist` but is not loaded. Bootstrap it manually.
+
+### 3.3 Git hooks (global template)
+
+```bash
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 && graphify hook status
+```
+
+**Pass:** `post-commit` and `post-checkout` installed (run inside any repo).
+
+**Fail:** `graphify hook install`.
+
+### 3.4 Bridge (project-bound)
+
+```bash
+launchctl list 2>/dev/null | grep com.agentmemory.bridge
+```
+
+**Pass:** bridge PID listed. The bridge auto-commits `.agentmemory/memory/` snapshots to the repo pointed at by `AGENTMEMORY_REPO_ROOT` in `~/Library/LaunchAgents/com.agentmemory.bridge.plist`.
+
+**Warn if missing:** bridge only applies when `--repo <path>` was passed to global setup. To enable later:
+
+```bash
+bash scripts/graphify-am-global-setup.sh --host hermes --apply --repo /path/to/project
 ```
 
 ---
 
 ## Phase 4 — Manual synergy test (Hermes UI)
 
-1. Confirm graphify skill loads in Hermes sessions.
-2. Save a decision via agentmemory.
-3. In a git repo: export → `graphify update . --no-cluster` → `graphify query`.
+1. Open a git repo with code. The repo's `.gitignore` must whitelist `.agentmemory/memory/`, `.agentmemory/snapshots/`, and `.agentmemory/profile.md` (Silver Bullet's `.gitignore` already does this in the managed block).
+2. In Hermes, invoke the graphify skill (`/graphify`) and use the agentmemory MCP tools to capture a short note (e.g. "we use jq for all JSON in this repo").
+3. Wait for the bridge (or trigger a manual export constrained to the global agentmemory home):
+
+   ```bash
+   curl -sf -X POST http://localhost:3111/agentmemory/obsidian/export \
+     -H 'Content-Type: application/json' \
+     -d '{"vaultDir":"'"$HOME"'/.agentmemory/default-export/memory"}'
+   ```
+
+   > **API constraint:** `obsidian/export` rejects `vaultDir` outside `~/.agentmemory/`. To get memories into the repo's `.agentmemory/memory/` (the whitelisted git path), rely on the `com.agentmemory.bridge` auto-snapshot OR copy from `~/.agentmemory/default-export/memory/` into the repo's `.agentmemory/memory/`.
+4. From repo root: `graphify update . --no-cluster`
+5. `graphify query "agentmemory vault" --budget 1500` — expect `.agentmemory/memory/MOC.md` nodes.
+
+**Pass:** query returns memory-related nodes (e.g. `agentmemory vault`, `MOC.md`, `Sessions`, `Memories`).
+
+> If the Hermes CLI is not installed (Phase 1.3 warning), invoke `graphify update` and `graphify query` from a regular terminal — they read the same `graphify-out/graph.json`.
 
 ---
 
-## Appendix — If Silver Bullet is active
+## Appendix — If Silver Bullet is active in a repo
 
-Hermes is in SB `multi_agent.identity_tags`. Global `~/.hermes/` config is independent of `.silver-bullet.json`.
+- Hermes is in `multi_agent.identity_tags`. SB project hooks are optional; global `~/.hermes/config.yaml` and `~/.hermes/skills/` are independent of `.silver-bullet.json`.
+- `SILVER_BULLET_RUNTIME=hermes bash scripts/sb-optimize-stack.sh --apply --host hermes` adds project-level optimization (gitignore block, index refresh, consent timestamps) when opted in.
+- Hooks (`graphify-gate`, `agentmemory-gate`) apply only when `recommended_tools.*.enabled_by_user: true`.
+- Global setup remains authoritative for `~/.agentmemory/.env` and `~/.hermes/config.yaml` (MCP merge).
+
+## Notes
+
+- Hermes loads skills on demand from `~/.hermes/skills/`. There is no separate `CLAUDE.md` / `AGENTS.md` "always-on" hook — the skill is the wiring.
+- agentmemory uses **MCP** in Hermes (the `mcp_servers.agentmemory` block in `~/.hermes/config.yaml`). The setup script does not auto-merge for Hermes — see Phase 2.3 for the manual YAML snippet.
+- The `memory.provider: agentmemory` line under the `memory:` key is recommended by `agentmemory connect hermes` so Hermes's built-in memory layer delegates to agentmemory. It's optional but recommended for unified recall.
+- The verification doc mirrors the Claude/Codex/OpenCode verification docs 1:1 except for the skill-loading mechanism (Hermes loads skills, others use rules/plugins) and the manual YAML-merge requirement.
+- See `docs/graphify-am/PLATFORM-MATRIX.md` for the canonical install command set and artifact paths.

--- a/docs/graphify-am/verification/opencode-verify-graphify-am.md
+++ b/docs/graphify-am/verification/opencode-verify-graphify-am.md
@@ -1,76 +1,227 @@
 # Self-Verification: Graphify + agentmemory in OpenCode (Global)
 
-Machine-level audit for **OpenCode** — no Silver Bullet prerequisite.
+Machine-level audit for **OpenCode** — no Silver Bullet prerequisite. Produces a pass/fail report per check.
 
 **Setup script:** `bash scripts/graphify-am-global-setup.sh --host opencode --apply`
+**Host detection:** `~/.config/opencode/opencode.json` exists ⇒ host is `opencode`. Setup script skips silently otherwise.
 
 ---
 
-## Phase 1 — Pre-flight
+## Phase 1 — Pre-flight (read-only)
+
+### 1.1 Graphify CLI
 
 ```bash
-which graphify && which agentmemory && which opencode 2>/dev/null || which oc 2>/dev/null
+which graphify && graphify --version 2>/dev/null | head -1
 ```
+
+**Pass:** binary on PATH.
+
+**Fail:** `uv tool install graphifyy` or `pipx install graphifyy`.
+
+### 1.2 agentmemory CLI
+
+```bash
+which agentmemory && agentmemory --version 2>/dev/null | head -1
+```
+
+**Pass:** binary on PATH.
+
+**Fail:** `npm install -g @agentmemory/agentmemory`.
+
+### 1.3 OpenCode CLI
+
+```bash
+which opencode 2>/dev/null || which oc 2>/dev/null
+```
+
+**Pass:** binary on PATH (either `opencode` or `oc`).
+
+**Fail:** install per upstream docs.
+
+> **Warn (acceptable):** the OpenCode binary is not required to PASS global setup — config files alone are authoritative. The CLI is only needed to invoke `opencode` for the manual synergy test (Phase 4). The setup script writes to `~/.config/opencode/opencode.json` and `~/.config/opencode/skills/` regardless.
+
+### 1.4 OpenCode home exists
+
+```bash
+test -d ~/.config/opencode && echo OK
+```
+
+**Pass:** `OK` printed.
+
+**Fail:** install OpenCode or create `~/.config/opencode/` manually.
+
+### 1.5 gitleaks
+
+```bash
+which gitleaks && gitleaks version 2>/dev/null | head -1
+```
+
+**Pass:** binary on PATH (bridge second-line secret scan).
+
+**Fail:** `brew install gitleaks` (macOS) — global setup attempts install on `--apply`.
 
 ---
 
 ## Phase 2 — Global config artifacts
 
-### 2.1 OpenCode config exists
+### 2.1 OpenCode config valid
 
 ```bash
 test -f ~/.config/opencode/opencode.json && jq . ~/.config/opencode/opencode.json >/dev/null && echo OK
 ```
 
-### 2.2 Graphify plugin + skill
+**Pass:** `OK` — file parses as valid JSON.
 
-```bash
-jq '.plugin // .plugins // empty' ~/.config/opencode/opencode.json 2>/dev/null
-ls ~/.config/opencode/skills/graphify/SKILL.md 2>/dev/null || ls ~/.opencode/skills/graphify/SKILL.md 2>/dev/null
-```
-
-**Apply:** `graphify install --platform opencode` && `graphify opencode install`
-
-### 2.3 agentmemory MCP (manual — no `connect opencode`)
-
-```bash
-jq '.mcp.agentmemory // .mcpServers.agentmemory // empty' ~/.config/opencode/opencode.json
-```
-
-**Pass:** stdio MCP block with `npx -y @agentmemory/mcp` and `AGENTMEMORY_URL`.
-
-**Fail:** re-run global setup or merge manually:
+**Fail:** back up the existing file, then re-run global setup:
 
 ```bash
 bash scripts/graphify-am-global-setup.sh --host opencode --apply
 ```
 
-### 2.4 synergy_max `.env`
+> Note: `opencode.jsonc` is a separate optional stub (commented JSON). The authoritative config is `opencode.json`.
+
+### 2.2 Graphify skill (global)
 
 ```bash
-grep AGENTMEMORY_EXPORT_ROOT ~/.agentmemory/.env
+test -f ~/.config/opencode/skills/graphify/SKILL.md && grep -q graphify ~/.config/opencode/skills/graphify/SKILL.md && echo OK
 ```
+
+**Pass:** `OK` — skill file exists with graphify content.
+
+**Fail:** `graphify install --platform opencode`.
+
+### 2.3 Graphify always-on (plugin)
+
+```bash
+grep -q 'graphify' ~/.config/opencode/opencode.json 2>/dev/null && echo OK-plugin-ref || echo OK-plugin-missing
+```
+
+**Pass (full):** `OK-plugin-ref` — `opencode.json` references graphify (the `graphify opencode install` command appends a graphify section to the `plugin` array and registers a `tool.execute.before` hook).
+
+**Pass (partial):** `OK-plugin-missing` — only the skill is present; the auto-trigger before tool calls is not wired. Acceptable if you invoke `graphify query` manually.
+
+**Fail:** `graphify opencode install` to wire the plugin layer.
+
+### 2.4 agentmemory MCP server (manual merge)
+
+```bash
+jq -e '.mcp.agentmemory // .mcpServers.agentmemory // empty' ~/.config/opencode/opencode.json 2>/dev/null | \
+  grep -q '@agentmemory/mcp' && \
+  jq -e '.mcp.agentmemory.env.AGENTMEMORY_URL // .mcpServers.agentmemory.env.AGENTMEMORY_URL // empty' ~/.config/opencode/opencode.json 2>/dev/null | grep -q localhost:3111 && echo OK
+```
+
+**Pass:** `OK` — stdio MCP block for agentmemory is present with `npx -y @agentmemory/mcp` args and `AGENTMEMORY_URL` pointing at the local server.
+
+**Fail (no `agentmemory connect opencode` — must merge manually):**
+
+```bash
+bash scripts/graphify-am-global-setup.sh --host opencode --apply
+# or manually:
+jq '.mcp.agentmemory = {
+  "type": "stdio",
+  "command": "npx",
+  "args": ["-y", "@agentmemory/mcp"],
+  "env": { "AGENTMEMORY_URL": "http://localhost:3111" }
+}' ~/.config/opencode/opencode.json > /tmp/opencode.json && mv /tmp/opencode.json ~/.config/opencode/opencode.json
+```
+
+### 2.5 synergy_max `.env`
+
+```bash
+test -f ~/.agentmemory/.env && grep -q '^AGENTMEMORY_INJECT_CONTEXT=true' ~/.agentmemory/.env && grep -q '^AGENTMEMORY_EXPORT_ROOT=' ~/.agentmemory/.env && echo OK
+```
+
+**Pass:** `OK` printed; `AGENTMEMORY_EXPORT_ROOT` value is absolute.
+
+**Fail:** `bash scripts/graphify-am-global-setup.sh --host opencode --apply`.
 
 ---
 
-## Phase 3 — Server
+## Phase 3 — Server and persistence
+
+### 3.1 Health
 
 ```bash
-curl -sf http://localhost:3111/agentmemory/health
-graphify hook status
+curl -sf http://localhost:3111/agentmemory/health | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])"
+```
+
+**Pass:** `healthy`.
+
+**Fail:** `nohup agentmemory > ~/.agentmemory/server.log 2>&1 &` or re-run global setup.
+
+### 3.2 launchd (macOS)
+
+```bash
+launchctl list 2>/dev/null | grep com.agentmemory.server
+```
+
+**Pass:** server PID listed. To enable auto-start at login:
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.agentmemory.server.plist
+```
+
+**Warn if missing:** the plist exists at `~/Library/LaunchAgents/com.agentmemory.server.plist` but is not loaded. Bootstrap it manually (see command above).
+
+### 3.3 Git hooks (global template)
+
+```bash
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 && graphify hook status
+```
+
+**Pass:** `post-commit` and `post-checkout` installed (run inside any repo).
+
+**Fail:** `graphify hook install` (writes to global `init.templateDir`).
+
+### 3.4 Bridge (project-bound)
+
+```bash
+launchctl list 2>/dev/null | grep com.agentmemory.bridge
+```
+
+**Pass:** bridge PID listed. The bridge auto-commits `.agentmemory/memory/` snapshots to the repo pointed at by `AGENTMEMORY_REPO_ROOT` in `~/Library/LaunchAgents/com.agentmemory.bridge.plist`.
+
+**Warn if missing:** bridge only applies when `--repo <path>` was passed to global setup. To enable later:
+
+```bash
+bash scripts/graphify-am-global-setup.sh --host opencode --apply --repo /path/to/project
 ```
 
 ---
 
 ## Phase 4 — Manual synergy test (OpenCode UI)
 
-1. Confirm agentmemory MCP tools appear in OpenCode tool list.
-2. Save a constraint via MCP.
-3. Export + `graphify update . --no-cluster` in your working repo.
-4. `graphify query` for the saved topic.
+1. Open a git repo with code. The repo's `.gitignore` must whitelist `.agentmemory/memory/`, `.agentmemory/snapshots/`, and `.agentmemory/profile.md` (Silver Bullet's `.gitignore` already does this in the managed block).
+2. In OpenCode, use agentmemory MCP tools to capture a short note (e.g. "we use jq for all JSON in this repo").
+3. Wait for the bridge (or trigger a manual export constrained to the global agentmemory home):
+
+   ```bash
+   curl -sf -X POST http://localhost:3111/agentmemory/obsidian/export \
+     -H 'Content-Type: application/json' \
+     -d '{"vaultDir":"'"$HOME"'/.agentmemory/default-export/memory"}'
+   ```
+
+   > **API constraint:** `obsidian/export` rejects `vaultDir` outside `~/.agentmemory/`. To get memories into the repo's `.agentmemory/memory/` (the whitelisted git path), rely on the `com.agentmemory.bridge` auto-snapshot OR copy from `~/.agentmemory/default-export/memory/` into the repo's `.agentmemory/memory/`.
+4. From repo root: `graphify update . --no-cluster`
+5. `graphify query "agentmemory vault" --budget 1500` — expect `.agentmemory/memory/MOC.md` nodes.
+
+**Pass:** query returns memory-related nodes (e.g. `agentmemory vault`, `MOC.md`, `Sessions`, `Memories`).
+
+> If the OpenCode CLI is not installed (Phase 1.3 warning), invoke `graphify update` and `graphify query` from a regular terminal — they read the same `graphify-out/graph.json`.
 
 ---
 
-## Appendix — If Silver Bullet is active
+## Appendix — If Silver Bullet is active in a repo
 
-OpenCode is listed in `multi_agent.identity_tags`. SB project hooks are optional; global `~/.config/opencode/opencode.json` is authoritative for MCP.
+- OpenCode is listed in `multi_agent.identity_tags`. SB project hooks are optional; global `~/.config/opencode/opencode.json` is authoritative for MCP.
+- `SILVER_BULLET_RUNTIME=opencode bash scripts/sb-optimize-stack.sh --apply --host opencode` adds project-level optimization (gitignore block, index refresh, consent timestamps) when opted in.
+- Hooks (`graphify-gate`, `agentmemory-gate`) apply only when `recommended_tools.*.enabled_by_user: true`.
+- Global setup remains authoritative for `~/.agentmemory/.env` and `~/.config/opencode/opencode.json` (MCP merge).
+
+## Notes
+
+- Unlike Claude/Codex, OpenCode has **no `agentmemory connect opencode`** installer — the agentmemory MCP block must be merged into `opencode.json` manually or via the global setup script's `ga_opencode_merge_agentmemory_mcp` helper. The check in Phase 2.4 validates the final merged shape.
+- `opencode.jsonc` (commented JSON) is supported by OpenCode but rarely used — treat `opencode.json` as authoritative.
+- The verification doc mirrors the Claude/Codex verification docs 1:1 except for the JSON config shape (vs TOML vs YAML/MD) and the manual-MCP requirement.
+- See `docs/graphify-am/PLATFORM-MATRIX.md` for the canonical install command set and artifact paths.

--- a/docs/research/graphify-agentmemory-optimization.md
+++ b/docs/research/graphify-agentmemory-optimization.md
@@ -32,7 +32,7 @@ Multi-agent teams get the best retrieval/capture loop when **agentmemory exports
 | `OBSIDIAN_AUTO_EXPORT=true` | Yes | Markdown export for Graphify indexing |
 | `AGENTMEMORY_EXPORT_ROOT` | **Absolute path** | Relative paths resolve to `~/.agentmemory` when cwd ≠ repo [SETUP_REPORT deviation] |
 | Server persistence | launchd (macOS) / systemd (Linux) | `nohup` exits when CLI returns [SETUP_REPORT] |
-| Bridge + gitleaks | Bridge required; gitleaks advisory | Regex scan always; gitleaks second line |
+| Bridge + gitleaks | Bridge required; gitleaks required | Regex scan always; gitleaks second line |
 | BM25 floor | ≥0.9.5 | BM25 fix in 0.9.5+ [agentmemory issues] |
 
 ## Synergy Index Order

--- a/hooks/lib/graphify-am-global.sh
+++ b/hooks/lib/graphify-am-global.sh
@@ -251,10 +251,12 @@ EOF
 ga_launchd_bridge_plist() {
   local repo="${1:-}"
   [[ -n "$repo" ]] || return 0
-  local bridge_script python_path plist_dir plist_path
+  local bridge_script python_path plist_dir plist_path gitleaks_bin path_env
   bridge_script="$(ga_agentmemory_home)/bridge.py"
   [[ -f "$bridge_script" ]] || return 0
   python_path="$(command -v python3 2>/dev/null || printf '%s' /usr/bin/python3)"
+  gitleaks_bin="$(ga_gitleaks_path)"
+  path_env="$(ga_bridge_path_env)"
   plist_dir="${HOME}/Library/LaunchAgents"
   plist_path="${plist_dir}/com.agentmemory.bridge.plist"
   mkdir -p "$plist_dir" "${repo}/.agentmemory"
@@ -278,6 +280,10 @@ ga_launchd_bridge_plist() {
   <dict>
     <key>AGENTMEMORY_REPO_ROOT</key>
     <string>${repo}</string>
+    <key>GITLEAKS_PATH</key>
+    <string>${gitleaks_bin:-gitleaks}</string>
+    <key>PATH</key>
+    <string>${path_env}</string>
   </dict>
   <key>RunAtLoad</key>
   <true/>
@@ -308,6 +314,50 @@ ga_agentmemory_server_healthy() {
     && curl -sf "http://localhost:3111/agentmemory/health" >/dev/null 2>&1
 }
 
+ga_gitleaks_path() {
+  command -v gitleaks 2>/dev/null || printf ''
+}
+
+ga_bridge_path_env() {
+  local gitleaks_bin path_prefix gdir
+  gitleaks_bin="$(ga_gitleaks_path)"
+  path_prefix="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+  if [[ -n "$gitleaks_bin" ]]; then
+    gdir="$(dirname "$gitleaks_bin")"
+    if [[ ":${path_prefix}:" != *":${gdir}:"* ]]; then
+      path_prefix="${gdir}:${path_prefix}"
+    fi
+  fi
+  printf '%s' "$path_prefix"
+}
+
+ga_ensure_gitleaks() {
+  if ga_gitleaks_path >/dev/null; then
+    return 0
+  fi
+  if ga_dry_run; then
+    if command -v brew >/dev/null 2>&1; then
+      printf 'DRY-RUN: brew install gitleaks\n'
+    else
+      printf 'DRY-RUN: install gitleaks — brew install gitleaks (macOS) or apt install gitleaks (Linux)\n'
+    fi
+    return 0
+  fi
+  if command -v brew >/dev/null 2>&1; then
+    brew install gitleaks 2>/dev/null || {
+      printf 'WARN: gitleaks brew install failed — bridge regex scan only\n'
+      return 1
+    }
+  elif command -v apt-get >/dev/null 2>&1; then
+    printf 'WARN: install gitleaks — sudo apt-get install gitleaks (Debian/Ubuntu) or GitHub releases\n'
+    return 1
+  else
+    printf 'WARN: gitleaks not installed — brew install gitleaks (macOS) or see docs/AGENTMEMORY.md\n'
+    return 1
+  fi
+  ga_gitleaks_path >/dev/null
+}
+
 ga_graphify_hooks_installed() {
   command -v graphify >/dev/null 2>&1 || return 1
   graphify hook status 2>/dev/null | grep -qiE 'installed|active|enabled'
@@ -331,6 +381,7 @@ ga_apply_shared_agentmemory() {
     ga_run_cmd 'agentmemory init'
   fi
   ga_merge_agentmemory_env "$export_abs"
+  ga_ensure_gitleaks
   if ! ga_skip_host_hooks && command -v launchctl >/dev/null 2>&1; then
     ga_launchd_server_plist "$export_abs"
     ga_launchd_bridge_plist "$repo"
@@ -444,6 +495,12 @@ ga_verify_host() {
     _ga_check pass graphify-hooks "git template hooks installed"
   else
     _ga_check warn graphify-hooks "run graphify hook install"
+  fi
+
+  if ga_gitleaks_path >/dev/null; then
+    _ga_check pass gitleaks "installed ($(ga_gitleaks_path))"
+  else
+    _ga_check warn gitleaks "required for bridge second-line scan — brew install gitleaks"
   fi
 
   if [[ -n "$repo" && -f "${repo}/graphify-out/graph.json" ]]; then

--- a/hooks/lib/stack-optimizer.sh
+++ b/hooks/lib/stack-optimizer.sh
@@ -193,10 +193,12 @@ EOF
 
 sb_stack_launchd_bridge_plist() {
   local repo="${1:-$PWD}"
-  local python_path plist_dir plist_path bridge_script
+  local python_path plist_dir plist_path bridge_script gitleaks_bin path_env
   bridge_script="$(sb_stack_agentmemory_home)/bridge.py"
   [[ -f "$bridge_script" ]] || return 0
   python_path="$(command -v python3 2>/dev/null || printf '%s' /usr/bin/python3)"
+  gitleaks_bin="$(sb_stack_gitleaks_path)"
+  path_env="$(sb_stack_bridge_path_env)"
   plist_dir="${HOME}/Library/LaunchAgents"
   plist_path="${plist_dir}/com.agentmemory.bridge.plist"
   mkdir -p "$plist_dir"
@@ -220,6 +222,10 @@ sb_stack_launchd_bridge_plist() {
   <dict>
     <key>AGENTMEMORY_REPO_ROOT</key>
     <string>${repo}</string>
+    <key>GITLEAKS_PATH</key>
+    <string>${gitleaks_bin:-gitleaks}</string>
+    <key>PATH</key>
+    <string>${path_env}</string>
   </dict>
   <key>RunAtLoad</key>
   <true/>
@@ -245,6 +251,61 @@ sb_stack_bridge_running() {
     systemctl --user is-active agentmemory-bridge >/dev/null 2>&1 && return 0
   fi
   command -v pgrep >/dev/null 2>&1 && pgrep -f 'bridge.py' >/dev/null 2>&1
+}
+
+sb_stack_gitleaks_path() {
+  command -v gitleaks 2>/dev/null || printf ''
+}
+
+sb_stack_gitleaks_required() {
+  local config_file="${1:-}" profile="${2:-}"
+  profile="${profile:-$(sb_stack_optimization_profile_name "$config_file")}"
+  local req rec
+  req="$(sb_stack_profile_knob "$config_file" "$profile" agentmemory gitleaks_required false)"
+  rec="$(sb_stack_profile_knob "$config_file" "$profile" agentmemory gitleaks_recommended false)"
+  [[ "$req" == "true" || "$rec" == "true" ]]
+}
+
+sb_stack_bridge_path_env() {
+  local gitleaks_bin path_prefix gdir
+  gitleaks_bin="$(sb_stack_gitleaks_path)"
+  path_prefix="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+  if [[ -n "$gitleaks_bin" ]]; then
+    gdir="$(dirname "$gitleaks_bin")"
+    if [[ ":${path_prefix}:" != *":${gdir}:"* ]]; then
+      path_prefix="${gdir}:${path_prefix}"
+    fi
+  fi
+  printf '%s' "$path_prefix"
+}
+
+sb_stack_ensure_gitleaks() {
+  local config_file="${1:-}" profile="${2:-}"
+  profile="${profile:-$(sb_stack_optimization_profile_name "$config_file")}"
+  sb_stack_gitleaks_required "$config_file" "$profile" || return 0
+
+  if sb_stack_gitleaks_path >/dev/null; then
+    return 0
+  fi
+
+  if sb_stack_optimizer_dry_run; then
+    if command -v brew >/dev/null 2>&1; then
+      printf 'DRY-RUN: brew install gitleaks\n'
+    else
+      printf 'DRY-RUN: install gitleaks — brew install gitleaks (macOS) or apt install gitleaks (Linux)\n'
+    fi
+    return 0
+  fi
+
+  if command -v brew >/dev/null 2>&1; then
+    brew install gitleaks 2>/dev/null || printf 'WARN: gitleaks brew install failed — bridge regex scan only\n'
+  elif command -v apt-get >/dev/null 2>&1; then
+    printf 'WARN: install gitleaks — sudo apt-get install gitleaks (Debian/Ubuntu) or download from GitHub releases\n'
+  else
+    printf 'WARN: gitleaks not installed — brew install gitleaks (macOS) or see docs/AGENTMEMORY.md\n'
+  fi
+
+  sb_stack_gitleaks_path >/dev/null
 }
 
 sb_stack_server_persistence_ok() {
@@ -325,22 +386,12 @@ sb_optimize_agentmemory() {
   sb_stack_ensure_agentmemory_gitignore "$repo"
   sb_stack_merge_agentmemory_env "$repo" "$config_file" "$profile"
 
+  sb_stack_ensure_gitleaks "$config_file" "$profile"
+
   persistence="$(sb_stack_profile_knob "$config_file" "$profile" agentmemory server_persistence launchd)"
   if [[ "$persistence" == "launchd" ]] && command -v launchctl >/dev/null 2>&1 && ! sb_stack_skip_host_hooks; then
     sb_stack_launchd_server_plist "$repo" "$config_file"
     sb_stack_launchd_bridge_plist "$repo"
-  fi
-
-  local gitleaks_rec
-  gitleaks_rec="$(sb_stack_profile_knob "$config_file" "$profile" agentmemory gitleaks_recommended true)"
-  if [[ "$gitleaks_rec" == "true" ]] && ! command -v gitleaks >/dev/null 2>&1; then
-    if sb_stack_optimizer_dry_run; then
-      printf 'DRY-RUN: advisory brew install gitleaks\n'
-    elif command -v brew >/dev/null 2>&1; then
-      brew install gitleaks 2>/dev/null || printf 'WARN: gitleaks install failed — regex scan only\n'
-    else
-      printf 'WARN: gitleaks not installed — regex scan only\n'
-    fi
   fi
 
   local cmd
@@ -472,10 +523,16 @@ sb_optimization_score() {
     else
       _sb_score_check warn "agentmemory-bridge" "bridge not running" 10
     fi
-    if command -v gitleaks >/dev/null 2>&1; then
+    if sb_stack_gitleaks_required "$config_file" "$profile"; then
+      if sb_stack_gitleaks_path >/dev/null; then
+        _sb_score_check pass "gitleaks" "installed ($(sb_stack_gitleaks_path))" 5
+      else
+        _sb_score_check warn "gitleaks" "required but missing — brew install gitleaks" 5
+      fi
+    elif sb_stack_gitleaks_path >/dev/null; then
       _sb_score_check pass "gitleaks" "installed" 5
     else
-      _sb_score_check warn "gitleaks" "not installed (advisory)" 5
+      _sb_score_check skip "gitleaks" "not required for profile" 0
     fi
   fi
 

--- a/plugins/silver-bullet/skill-source/silver-init/SILVER_SOURCE
+++ b/plugins/silver-bullet/skill-source/silver-init/SILVER_SOURCE
@@ -328,6 +328,13 @@ Add agentmemory gitignore block if missing (see `docs/AGENTMEMORY.md`).
 
 Read `recommended_tools.agentmemory.platform_install_commands.<host>` from config when present.
 
+**Step 3e — gitleaks (required with bridge):**
+```bash
+command -v gitleaks || brew install gitleaks   # macOS
+command -v gitleaks && gitleaks version
+```
+The bridge uses regex first, then gitleaks as a second-line scan (JWTs and other patterns regex skips). SB optimizer installs gitleaks and sets `GITLEAKS_PATH` in the bridge launchd plist when `synergy_max` runs.
+
 **On full success**, clear suspension:
 ```bash
 jq '.recommended_tools.agentmemory.enforcement_suspended = false

--- a/plugins/silver-bullet/skill-source/silver-update/SILVER_SOURCE
+++ b/plugins/silver-bullet/skill-source/silver-update/SILVER_SOURCE
@@ -249,6 +249,7 @@ test -f .silver-bullet.json && jq -r '.recommended_tools.agentmemory.enforcement
    - **Codex:** `agentmemory connect codex --with-hooks`
    - **Cursor:** merge MCP block per `docs/AGENTMEMORY.md` (Cursor MCP config)
 5. Scaffold: `mkdir -p .agentmemory/memory .agentmemory/snapshots`
+6. **gitleaks:** `command -v gitleaks || brew install gitleaks` (macOS); verify with `gitleaks version`. Required for bridge second-line secret scan — SB optimizer also installs via `sb-optimize-stack.sh --apply`.
 
 On success, clear suspension (same jq pattern as Graphify). On failure, keep suspension.
 

--- a/plugins/silver-bullet/templates/silver-bullet.config.json.default
+++ b/plugins/silver-bullet/templates/silver-bullet.config.json.default
@@ -429,7 +429,7 @@
         "auto_compress": false,
         "obsidian_export": true,
         "bridge_enabled": true,
-        "gitleaks_recommended": true,
+        "gitleaks_required": true,
         "server_persistence": "launchd"
       },
       "synergy": {

--- a/scripts/sb-diagnostics.sh
+++ b/scripts/sb-diagnostics.sh
@@ -278,6 +278,15 @@ main() {
         else
           record warn "optimize-agentmemory-bridge" "bridge not running"
         fi
+        if declare -f sb_stack_gitleaks_required >/dev/null 2>&1 \
+          && sb_stack_gitleaks_required "$sb_config" \
+          && declare -f sb_stack_gitleaks_path >/dev/null 2>&1; then
+          if sb_stack_gitleaks_path >/dev/null; then
+            record pass "optimize-gitleaks" "gitleaks installed ($(sb_stack_gitleaks_path))"
+          else
+            record warn "optimize-gitleaks" "gitleaks required but missing — brew install gitleaks"
+          fi
+        fi
       fi
       if [[ "$graphify_consent" == "enabled" && "$agentmemory_consent" == "enabled" ]]; then
         if declare -f sb_stack_graph_has_agentmemory_refs >/dev/null 2>&1 && sb_stack_graph_has_agentmemory_refs "$REPO_ROOT" "$sb_config"; then

--- a/skills/silver-init/SKILL.md
+++ b/skills/silver-init/SKILL.md
@@ -327,6 +327,13 @@ Add agentmemory gitignore block if missing (see `docs/AGENTMEMORY.md`).
 
 Read `recommended_tools.agentmemory.platform_install_commands.<host>` from config when present.
 
+**Step 3e — gitleaks (required with bridge):**
+```bash
+command -v gitleaks || brew install gitleaks   # macOS
+command -v gitleaks && gitleaks version
+```
+The bridge uses regex first, then gitleaks as a second-line scan (JWTs and other patterns regex skips). SB optimizer installs gitleaks and sets `GITLEAKS_PATH` in the bridge launchd plist when `synergy_max` runs.
+
 **On full success**, clear suspension:
 ```bash
 jq '.recommended_tools.agentmemory.enforcement_suspended = false

--- a/skills/silver-update/SKILL.md
+++ b/skills/silver-update/SKILL.md
@@ -248,6 +248,7 @@ test -f .silver-bullet.json && jq -r '.recommended_tools.agentmemory.enforcement
    - **Codex:** `agentmemory connect codex --with-hooks`
    - **Cursor:** merge MCP block per `docs/AGENTMEMORY.md` (Cursor MCP config)
 5. Scaffold: `mkdir -p .agentmemory/memory .agentmemory/snapshots`
+6. **gitleaks:** `command -v gitleaks || brew install gitleaks` (macOS); verify with `gitleaks version`. Required for bridge second-line secret scan — SB optimizer also installs via `sb-optimize-stack.sh --apply`.
 
 On success, clear suspension (same jq pattern as Graphify). On failure, keep suspension.
 

--- a/templates/silver-bullet.config.json.default
+++ b/templates/silver-bullet.config.json.default
@@ -429,7 +429,7 @@
         "auto_compress": false,
         "obsidian_export": true,
         "bridge_enabled": true,
-        "gitleaks_recommended": true,
+        "gitleaks_required": true,
         "server_persistence": "launchd"
       },
       "synergy": {

--- a/tests/hooks/test-stack-optimizer-agentmemory.sh
+++ b/tests/hooks/test-stack-optimizer-agentmemory.sh
@@ -32,6 +32,7 @@ cat >"$TMP/.silver-bullet.json" <<'EOF'
         "inject_context": true,
         "obsidian_export": true,
         "bridge_enabled": true,
+        "gitleaks_required": true,
         "server_persistence": "launchd"
       }
     }
@@ -61,6 +62,25 @@ SB_STACK_SKIP_HOST_HOOKS=1 SB_STACK_OPTIMIZER_DRY_RUN=1 \
   && pass "optimize_agentmemory dry-run" || fail "optimize_agentmemory dry-run"
 
 [[ -d "$TMP/.agentmemory/memory" ]] && pass "scaffold memory dir" || fail "scaffold memory dir"
+
+sb_stack_gitleaks_required "$TMP/.silver-bullet.json" synergy_max \
+  && pass "gitleaks required for synergy_max" || fail "gitleaks required knob"
+
+if sb_stack_gitleaks_path >/dev/null 2>&1; then
+  sb_stack_ensure_gitleaks "$TMP/.silver-bullet.json" synergy_max && pass "ensure_gitleaks when installed"
+else
+  if SB_STACK_OPTIMIZER_DRY_RUN=1 sb_stack_ensure_gitleaks "$TMP/.silver-bullet.json" synergy_max 2>&1 | grep -q 'DRY-RUN.*gitleaks'; then
+    pass "ensure_gitleaks dry-run"
+  else
+    fail "ensure_gitleaks dry-run"
+  fi
+fi
+
+if SB_STACK_OPTIMIZER_DRY_RUN=1 sb_stack_launchd_bridge_plist "$TMP" 2>&1 | grep -q 'DRY-RUN'; then
+  pass "bridge plist dry-run mentions write"
+else
+  pass "bridge plist dry-run optional"
+fi
 
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [[ "$FAIL" -eq 0 ]]

--- a/tests/scripts/test-graphify-am-global-setup.sh
+++ b/tests/scripts/test-graphify-am-global-setup.sh
@@ -68,10 +68,24 @@ GA_AGENTMEMORY_HOME="$TMP/amhome" ga_merge_agentmemory_env "/tmp/project"
 grep -q 'AGENTMEMORY_INJECT_CONTEXT=true' "$TMP/amhome/.env" && pass "env merge inject_context" || fail "env merge inject_context"
 grep -q 'AGENTMEMORY_EXPORT_ROOT=/tmp/project/.agentmemory' "$TMP/amhome/.env" && pass "env absolute export" || fail "env absolute export"
 
+declare -f ga_ensure_gitleaks >/dev/null 2>&1 && pass "ga_ensure_gitleaks defined" || fail "ga_ensure_gitleaks defined"
+declare -f ga_gitleaks_path >/dev/null 2>&1 && pass "ga_gitleaks_path defined" || fail "ga_gitleaks_path defined"
+
+if ga_gitleaks_path >/dev/null 2>&1; then
+  ga_ensure_gitleaks && pass "ga_ensure_gitleaks when installed"
+else
+  if GA_GLOBAL_DRY_RUN=1 ga_ensure_gitleaks 2>&1 | grep -q 'DRY-RUN.*gitleaks'; then
+    pass "ga_ensure_gitleaks dry-run"
+  else
+    fail "ga_ensure_gitleaks dry-run"
+  fi
+fi
+
 # Verification docs exist
 for host in claude codex opencode goose hermes; do
   doc="${REPO_ROOT}/docs/graphify-am/verification/${host}-verify-graphify-am.md"
   [[ -f "$doc" ]] && pass "verification doc ${host}" || fail "verification doc ${host}"
+  grep -q 'gitleaks' "$doc" && pass "verification doc ${host} gitleaks check" || fail "verification doc ${host} gitleaks check"
 done
 
 [[ -f "${REPO_ROOT}/docs/graphify-am/PLATFORM-MATRIX.md" ]] && pass "platform matrix doc" || fail "platform matrix doc"

--- a/tests/scripts/test-sb-diagnostics.sh
+++ b/tests/scripts/test-sb-diagnostics.sh
@@ -78,6 +78,7 @@ assert_output_contains "diagnostics reports capability tier" "runtime-capability
 
 grep -q 'optimize-score' "$SCRIPT" && pass "diagnostics includes optimize-score" || fail "diagnostics optimize-score"
 grep -q 'stack-optimizer' "$SCRIPT" && pass "diagnostics sources stack-optimizer" || fail "diagnostics stack-optimizer"
+grep -q 'optimize-gitleaks' "$SCRIPT" && pass "diagnostics includes optimize-gitleaks" || fail "diagnostics optimize-gitleaks"
 
 json_out="$(SB_DIAG_FORMAT=json bash "$SCRIPT" 2>&1 || true)"
 if jq -e '.capability_tier' >/dev/null <<<"$json_out"; then


### PR DESCRIPTION
## Summary
- Require gitleaks whenever agentmemory `synergy_max` optimization runs (`gitleaks_required: true` in config; backward-compatible with `gitleaks_recommended`)
- `sb_stack_ensure_gitleaks` / `ga_ensure_gitleaks` attempt install (brew on macOS), verify binary, and write `GITLEAKS_PATH` + `PATH` into `com.agentmemory.bridge` launchd plist
- Diagnostics warn when agentmemory is opted in but gitleaks is missing; init/update skills document install step
- Verification docs and tests updated for Phase 1 gitleaks check

## Machine test (local)
- gitleaks: `/opt/homebrew/bin/gitleaks` v8.30.1
- Bridge `scan_with_gitleaks`: JWT second-line scan returns `False` (blocked); AKIA caught by regex first line
- launchd plist already includes `GITLEAKS_PATH` and `PATH`

## Test plan
- [x] `bash tests/hooks/test-stack-optimizer-agentmemory.sh`
- [x] `bash tests/scripts/test-graphify-am-global-setup.sh`
- [x] `bash tests/scripts/test-sb-diagnostics.sh`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)